### PR TITLE
Issue #42: include multi-script bundle in repo release deliverables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Documented Issue #42 repo release deliverables so GitHub repo releases explicitly include `dist/sloppy-ethos_scripts.zip` alongside single-script ZIP assets, including the build step `python tools/build.py --project SensorList --project ethos_events --dist`.
+
 ## [1.0.1] - 2026-02-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ luac -p scripts/SensorList/main.lua
 - Release scope is explicit:
   - repo releases track repository-wide workflow/docs/versioning changes.
   - script releases track installable script artifacts and script-specific manual gates.
+- Repo release install deliverables include:
+  - `dist/sloppy-ethos_scripts.zip` (built via `python tools/build.py --project SensorList --project ethos_events --dist`)
+  - single-script ZIPs for each included script release asset (for example `dist/SensorList-{version}.zip` and `dist/ethos_events-{version}.zip`)
+- Release publishing checklist for repo releases:
+  - run `python tools/build.py --project SensorList --project ethos_events --dist`
+  - attach `dist/sloppy-ethos_scripts.zip` alongside the single-script ZIP assets in the GitHub release
 - Main-branch workflow, branch naming conventions, version bump timing, optional `-rc.N`, and release-prep flow:
   [Development policy](docs/DEVELOPMENT.md#main-branch-release-and-versioning-policy).
 - Published release notes and install assets: [GitHub Releases](https://github.com/doppleganger53/sloppy-ethos/releases).
@@ -133,7 +139,7 @@ luac -p scripts/SensorList/main.lua
 
 - Script idea: smart switch map that pre-populates mapped switches and identifies unused switches
 - optimize agentic and human workflows in the repo
-- [#42](https://github.com/doppleganger53/sloppy-ethos/issues/42) Include the multi-script bundle as a repo release deliverable.
+- Completed [#42](https://github.com/doppleganger53/sloppy-ethos/issues/42): repo releases now include the multi-script bundle deliverable `dist/sloppy-ethos_scripts.zip`.
 
 ### SensorList
 

--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,11 +15,11 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-- Files: 71
-- Total size: 104,390 bytes
-- Total lines: 2,551
+- Files: 72
+- Total size: 106,591 bytes
+- Total lines: 2,596
 - Distribution by category:
-  - session notes: 66
+  - session notes: 67
   - handoff/restart notes: 3
   - domain notes: 1
   - monthly summaries: 1
@@ -28,8 +28,8 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
   - 13 -- memory-ops ( Agentic context engineering )
   - 12 -- lua-ethos ( Ethos targeted scripts )
   - 10 -- build-tooling ( Build, deploy, packaging, and tooling workflows )
+  - 8 -- release-versioning ( Release flow, tagging, and version policy )
   - 7 -- docs-process ( Documentation and contributor process changes )
-  - 7 -- release-versioning ( Release flow, tagging, and version policy )
   - 5 -- testing ( Automated tests and coverage changes )
   - 5 -- workflow-policy ( Branching, policy, and workflow guardrails )
   - 4 -- issue-lifecycle ( Issue creation, validation, and closure tracking )
@@ -42,11 +42,11 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 - Selection: newest session notes where `Focus` is one of `build-tooling`, `docs-process`, `release-versioning`, `repo`, `testing`, or `workflow-policy`; keep up to 3 per focus, then keep newest 12 overall.
 - 2026-02-27 | release-versioning | [notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V101.md](notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V101.md) | # Session Notes 2026-02-27 - Release v1.0.1
 - 2026-02-27 | release-versioning | [notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V100.md](notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V100.md) | # Session Notes 2026-02-27 - Release v1.0.0
+- 2026-02-27 | release-versioning | [notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_ISSUE_42_MULTI_SCRIPT_RELEASE_DELIVERABLE.md](notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_ISSUE_42_MULTI_SCRIPT_RELEASE_DELIVERABLE.md) | # Session Notes 2026-02-27 - Issue #42 Multi-script Release Deliverable
 - 2026-02-27 | workflow-policy | [notes/session-note/workflow-policy/SESSION_NOTES_2026-02-27_ISSUE_39_RELEASE_SCOPE_CLARITY.md](notes/session-note/workflow-policy/SESSION_NOTES_2026-02-27_ISSUE_39_RELEASE_SCOPE_CLARITY.md) | # Session Notes 2026-02-27 - Issue #39 Release Scope Clarity
 - 2026-02-27 | testing | [notes/session-note/testing/SESSION_NOTES_2026-02-27_ISSUE_16_SESSION_PREFLIGHT_TEST_COVERAGE.md](notes/session-note/testing/SESSION_NOTES_2026-02-27_ISSUE_16_SESSION_PREFLIGHT_TEST_COVERAGE.md) | # Session Notes 2026-02-27 - Issue #16 session_preflight test coverage
 - 2026-02-27 | testing | [notes/session-note/testing/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md](notes/session-note/testing/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md) | # Session Notes 2026-02-27 - Issue #16 Catalog Test Portability
 - 2026-02-27 | workflow-policy | [notes/session-note/workflow-policy/SESSION_NOTES_2026-02-27_ISSUE_16_BRANCH_GATE_HARDENING.md](notes/session-note/workflow-policy/SESSION_NOTES_2026-02-27_ISSUE_16_BRANCH_GATE_HARDENING.md) | # Session Notes 2026-02-27 - Issue #16 Branch Gate Hardening
-- 2026-02-26 | release-versioning | [notes/session-note/release-versioning/SESSION_NOTES_2026-02-26_V020_MILESTONE_18_20_25.md](notes/session-note/release-versioning/SESSION_NOTES_2026-02-26_V020_MILESTONE_18_20_25.md) | # Session Notes 2026-02-26 - v0.2.0 Milestone Issues #18 #20 #25
 - 2026-02-26 | repo | [notes/session-note/repo/SESSION_NOTES_2026-02-26_REPO_METADATA_DESCRIPTION_TOPICS.md](notes/session-note/repo/SESSION_NOTES_2026-02-26_REPO_METADATA_DESCRIPTION_TOPICS.md) | # Session Notes 2026-02-26 - Repository Metadata Description and Topics
 - 2026-02-26 | build-tooling | [notes/session-note/build-tooling/SESSION_NOTES_2026-02-26_ISSUE_22_DOIT_MIGRATION_EVALUATION.md](notes/session-note/build-tooling/SESSION_NOTES_2026-02-26_ISSUE_22_DOIT_MIGRATION_EVALUATION.md) | # Session Notes 2026-02-26 - Issue #22 `build.py` to `doit` Migration Evaluation
 - 2026-02-26 | docs-process | [notes/session-note/docs-process/SESSION_NOTES_2026-02-26_DOC_COMMANDS_MANUAL_REFACTOR.md](notes/session-note/docs-process/SESSION_NOTES_2026-02-26_DOC_COMMANDS_MANUAL_REFACTOR.md) | # Session Notes 2026-02-26 - Docs Command Manual Classification Refactor
@@ -122,6 +122,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-02-27 | session-note | memory-ops | [notes/session-note/memory-ops/SESSION_NOTES_2026-02-27_ISSUE_16_MEMORY_NOTES_FOLDER_STRUCTURE.md](notes/session-note/memory-ops/SESSION_NOTES_2026-02-27_ISSUE_16_MEMORY_NOTES_FOLDER_STRUCTURE.md) | # Session Notes 2026-02-27 - Issue #16 Memory Notes Folder Structure |
 | 2026-02-27 | session-note | memory-ops | [notes/session-note/memory-ops/SESSION_NOTES_2026-02-27_ISSUE_16_MEMORY_SYNC_AUTOMATION.md](notes/session-note/memory-ops/SESSION_NOTES_2026-02-27_ISSUE_16_MEMORY_SYNC_AUTOMATION.md) | # Session Notes 2026-02-27 - Issue #16 Memory Sync Automation |
 | 2026-02-27 | session-note | memory-ops | [notes/session-note/memory-ops/SESSION_NOTES_2026-02-27_ISSUE_16_REPO_FOCUS_UNIFICATION.md](notes/session-note/memory-ops/SESSION_NOTES_2026-02-27_ISSUE_16_REPO_FOCUS_UNIFICATION.md) | # Session Notes 2026-02-27 - Issue #16 Repo Focus Unification |
+| 2026-02-27 | session-note | release-versioning | [notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_ISSUE_42_MULTI_SCRIPT_RELEASE_DELIVERABLE.md](notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_ISSUE_42_MULTI_SCRIPT_RELEASE_DELIVERABLE.md) | # Session Notes 2026-02-27 - Issue #42 Multi-script Release Deliverable |
 | 2026-02-27 | session-note | release-versioning | [notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V100.md](notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V100.md) | # Session Notes 2026-02-27 - Release v1.0.0 |
 | 2026-02-27 | session-note | release-versioning | [notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V101.md](notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_RELEASE_V101.md) | # Session Notes 2026-02-27 - Release v1.0.1 |
 | 2026-02-27 | session-note | testing | [notes/session-note/testing/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md](notes/session-note/testing/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md) | # Session Notes 2026-02-27 - Issue #16 Catalog Test Portability |

--- a/deslopification/memory/CURRENT_STATE.md
+++ b/deslopification/memory/CURRENT_STATE.md
@@ -11,6 +11,8 @@ Historical detail remains in individual session notes referenced from
 - Script artifact versions: `scripts/{ProjectName}/VERSION`.
 - Single-script ZIP naming: `dist/{ProjectName}-{version}.zip`.
 - Multi-script ZIP naming exception: `dist/sloppy-ethos_scripts.zip`.
+- Repo release asset baseline: include `dist/sloppy-ethos_scripts.zip` alongside
+  applicable single-script ZIP artifacts.
 
 ## Workflow Baseline
 

--- a/deslopification/memory/notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_ISSUE_42_MULTI_SCRIPT_RELEASE_DELIVERABLE.md
+++ b/deslopification/memory/notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_ISSUE_42_MULTI_SCRIPT_RELEASE_DELIVERABLE.md
@@ -1,0 +1,45 @@
+# Session Notes 2026-02-27 - Issue #42 Multi-script Release Deliverable
+
+## Note Placement
+
+- Category: `session-note`
+- Focus: `release-versioning`
+
+## What changed
+
+- Implemented Issue #42 by documenting repo release deliverables in `README.md`, including the required multi-script archive `dist/sloppy-ethos_scripts.zip`, the build command, and GitHub release asset attachment guidance.
+- Updated `docs/DEVELOPMENT.md` repository release workflow to include the multi-script bundle build step, explicit deliverable list, and release publish command that includes the bundle and single-script artifacts.
+- Added an `Unreleased` changelog entry in `CHANGELOG.md` summarizing the Issue #42 release-deliverable documentation update.
+- Updated `deslopification/memory/CURRENT_STATE.md` to record the durable repo release asset baseline.
+- Files touched:
+  - `README.md`
+  - `docs/DEVELOPMENT.md`
+  - `CHANGELOG.md`
+  - `deslopification/memory/CURRENT_STATE.md`
+  - `deslopification/memory/notes/session-note/release-versioning/SESSION_NOTES_2026-02-27_ISSUE_42_MULTI_SCRIPT_RELEASE_DELIVERABLE.md`
+  - `deslopification/memory/CATALOG.md`
+
+## Why
+
+- Root cause or objective:
+  - Ensure repository release guidance explicitly includes publishing the multi-script bundle deliverable so release assets are complete and consistent with existing build behavior.
+- Scope guardrails:
+  - No Lua widget/runtime behavior changes in `scripts/**/*.lua`.
+  - No build-tool behavior changes in `tools/build.py`; this session is documentation + workflow clarity only.
+
+## Validation run(s)
+
+- `python tools/build.py --project SensorList --project ethos_events --dist`
+  - result: pass; generated `dist/sloppy-ethos_scripts.zip`.
+- `python -m zipfile -l dist/sloppy-ethos_scripts.zip`
+  - result: pass; archive contains both `scripts/SensorList/` and `scripts/ethos_events/`.
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
+  - result: 91 passed, 14 skipped.
+
+## Follow-up items
+
+- Ensure the next repo release attaches `dist/sloppy-ethos_scripts.zip` plus applicable single-script ZIP assets during GitHub release publication.
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: yes

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -171,8 +171,13 @@ This repository uses `main` as the only long-lived integration branch and aligns
    - root `VERSION`
    - `CHANGELOG.md`
    - any repo-level workflow/docs/process files
-2. Do not treat script-only manual gates as implicit blockers unless that script is in scope.
-3. Publish release notes with `gh release create v{VERSION} --title "{TITLE}" --notes-file {notes-file}`.
+2. Build repo release install artifacts:
+   - `python tools/build.py --project SensorList --project ethos_events --dist`
+3. Ensure GitHub release assets include:
+   - `dist/sloppy-ethos_scripts.zip`
+   - included single-script ZIP artifacts (for example `dist/SensorList-{scripts/SensorList/VERSION}.zip` and `dist/ethos_events-{scripts/ethos_events/VERSION}.zip`)
+4. Do not treat script-only manual gates as implicit blockers unless that script is in scope.
+5. Publish release notes and install assets with `gh release create v{VERSION} dist/sloppy-ethos_scripts.zip dist/SensorList-{scripts/SensorList/VERSION}.zip dist/ethos_events-{scripts/ethos_events/VERSION}.zip --title "{TITLE}" --notes-file {notes-file}`.
 
 ### Script Release (`release-kind=script`)
 


### PR DESCRIPTION
## Summary\n- document repo release deliverables to include dist/sloppy-ethos_scripts.zip\n- add explicit repo release build/publish checklist for multi-script + single-script assets\n- add changelog and memory sync entries for issue #42\n\n## Validation\n- python tools/build.py --project SensorList --project ethos_events --dist\n- python -m zipfile -l dist/sloppy-ethos_scripts.zip\n- python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q\n\nCloses #42