### PR TITLE
Release SensorList v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [SensorList v1.0.1] - 2026-03-09
+
+### Changed
+
+- Released the `SensorList` script artifact at `1.0.1`, anchored on Issue #14, adding an optional persisted `Display Value` column while preserving the default four-column layout when the option is disabled.
+- Included the Issue #58 stabilization fix so visible value updates no longer use the unsafe `wakeup()` full-refresh path and instead refresh only the displayed row values without rebuilding the full sensor list.
+- Issue #32 manual validation gate was already closed before release publication.
+- Repository version remains `1.0.3`; this entry tracks the script-scoped release only.
+
+### Testing
+
+- `luac -p scripts/SensorList/main.lua`
+- `python -m pytest tests/test_sensorlist_widget.py -q`
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
+- `python tools/build.py --project SensorList --dist`
+
 ## [1.0.3] - 2026-03-02
 
 ### Changed

--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,31 +15,27 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-
-- Files: 100
-- Total size: 164,430 bytes
-- Total lines: 4,406
+- Files: 103
+- Total size: 169,462 bytes
+- Total lines: 4,546
 - Distribution by artifact:
-  - session notes: 94
+  - session notes: 97
   - handoff/restart notes: 3
   - reference notes: 2
   - summary notes: 1
 
 - Distribution by scope:
-
-  - 55 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
-  - 16 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
+  - 57 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
+  - 17 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
   - 15 -- memory ( Memory system structure and retrieval policy )
   - 7 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
   - 4 -- ethos-events ( ethos_events-specific behavior, release history, and operating notes )
   - 3 -- handoff ( Session continuity and restart handoffs )
 
 - Distribution by concern:
-
-  - 25 -- workflow
+  - 26 -- workflow
   - 24 -- implementation
-
-  - 14 -- release
+  - 15 -- release
   - 11 -- build
   - 9 -- docs
   - 6 -- testing
@@ -50,16 +46,14 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 ## Recent High-Signal Notes (Auto-generated)
 
 - Selection: newest session notes where `Concern` is one of `build`, `docs`, `metadata`, `release`, `testing`, or `workflow`; keep up to 3 per concern, then keep newest 12 overall.
-
+- 2026-03-09 | release | sensorlist | [notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md) | # Session Notes 2026-03-09 - SensorList-v1.0.1 Release
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md](notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md) | # Session Notes 2026-03-08 - VS Code Lua Coverage Workflow
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md](notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md) | # Session Notes 2026-03-08 - Debug Sessions Require Deploy
 - 2026-03-08 | build | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_BUILD_CLEAN_ORDER_FIX.md](notes/session/repo/SESSION_NOTES_2026-03-08_BUILD_CLEAN_ORDER_FIX.md) | # Session Notes 2026-03-08 - Build Clean Order Fix
-
+- 2026-03-05 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md) | # Session Notes 2026-03-05 - Issue #56 Mutable Workflow Agent Metadata
 - 2026-03-05 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_54_LOW_SIGNAL_TEST_PRUNING.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_54_LOW_SIGNAL_TEST_PRUNING.md) | # Session Notes 2026-03-05 - Issue #54 Low-Signal Test Pruning
-- 2026-03-02 | workflow | memory | [notes/session/memory/SESSION_NOTES_2026-03-02_WEEKLY_SUMMARY_COMPACTION.md](notes/session/memory/SESSION_NOTES_2026-03-02_WEEKLY_SUMMARY_COMPACTION.md) | # Session Notes 2026-03-02 - Weekly Summary Compaction
 - 2026-03-02 | release | sensorlist | [notes/session/sensorlist/SESSION_NOTES_2026-03-02_SENSORLIST_V100_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-02_SENSORLIST_V100_RELEASE.md) | # Session Notes 2026-03-02 - SensorList-v1.0.0 Release
 - 2026-03-02 | release | repo | [notes/session/repo/SESSION_NOTES_2026-03-02_REPO_RELEASE_CONSOLIDATED_BUNDLE_ONLY.md](notes/session/repo/SESSION_NOTES_2026-03-02_REPO_RELEASE_CONSOLIDATED_BUNDLE_ONLY.md) | # Session Notes 2026-03-02 - Repo Releases Consolidated Bundle Only
-- 2026-03-02 | release | repo | [notes/session/repo/SESSION_NOTES_2026-03-02_RELEASE_V103.md](notes/session/repo/SESSION_NOTES_2026-03-02_RELEASE_V103.md) | # Session Notes 2026-03-02 - Release v1.0.3
 - 2026-03-02 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-03-02_GOOD_FIRST_ISSUE_GUIDANCE_REMOVAL.md](notes/session/repo/SESSION_NOTES_2026-03-02_GOOD_FIRST_ISSUE_GUIDANCE_REMOVAL.md) | # Session Notes 2026-03-02 - Contributing Good First Issue Guidance Removal
 - 2026-02-27 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_SESSION_PREFLIGHT_TEST_COVERAGE.md](notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_SESSION_PREFLIGHT_TEST_COVERAGE.md) | # Session Notes 2026-02-27 - Issue #16 session_preflight test coverage
 - 2026-02-27 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md](notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md) | # Session Notes 2026-02-27 - Issue #16 Catalog Test Portability
@@ -173,10 +167,12 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-03-02 | session | sensorlist | implementation | [notes/session/sensorlist/SESSION_NOTES_2026-03-02_ISSUE_48_SENSORLIST_SUBID_CONFLICTS.md](notes/session/sensorlist/SESSION_NOTES_2026-03-02_ISSUE_48_SENSORLIST_SUBID_CONFLICTS.md) | # Session Notes 2026-03-02 - Issue #48 SensorList SubID Conflicts |
 | 2026-03-02 | session | sensorlist | release | [notes/session/sensorlist/SESSION_NOTES_2026-03-02_SENSORLIST_V100_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-02_SENSORLIST_V100_RELEASE.md) | # Session Notes 2026-03-02 - SensorList-v1.0.0 Release |
 | 2026-03-05 | session | repo | testing | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_54_LOW_SIGNAL_TEST_PRUNING.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_54_LOW_SIGNAL_TEST_PRUNING.md) | # Session Notes 2026-03-05 - Issue #54 Low-Signal Test Pruning |
+| 2026-03-05 | session | repo | issue-admin | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_AGENT_METADATA_TODO_TRACKING.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_AGENT_METADATA_TODO_TRACKING.md) | # Session Notes 2026-03-05 - Issue #56 Agent Metadata TODO Tracking |
+| 2026-03-05 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md) | # Session Notes 2026-03-05 - Issue #56 Mutable Workflow Agent Metadata |
 | 2026-03-06 | session | sensorlist | implementation | [notes/session/sensorlist/SESSION_NOTES_2026-03-06_ISSUE_14_SENSOR_VALUES_COLUMN.md](notes/session/sensorlist/SESSION_NOTES_2026-03-06_ISSUE_14_SENSOR_VALUES_COLUMN.md) | # Session Notes 2026-03-06 - Issue #14 Sensor Values Column |
 | 2026-03-07 | session | sensorlist | implementation | [notes/session/sensorlist/SESSION_NOTES_2026-03-07_ISSUE_58_SENSORLIST_VALUE_POLLING.md](notes/session/sensorlist/SESSION_NOTES_2026-03-07_ISSUE_58_SENSORLIST_VALUE_POLLING.md) | # Session Notes 2026-03-07 - Issue #58 SensorList Value Polling |
 | 2026-03-08 | session | repo | build | [notes/session/repo/SESSION_NOTES_2026-03-08_BUILD_CLEAN_ORDER_FIX.md](notes/session/repo/SESSION_NOTES_2026-03-08_BUILD_CLEAN_ORDER_FIX.md) | # Session Notes 2026-03-08 - Build Clean Order Fix |
 | 2026-03-08 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md](notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md) | # Session Notes 2026-03-08 - Debug Sessions Require Deploy |
 | 2026-03-08 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md](notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md) | # Session Notes 2026-03-08 - VS Code Lua Coverage Workflow |
 | 2026-03-08 | session | sensorlist | implementation | [notes/session/sensorlist/SESSION_NOTES_2026-03-08_SENSORLIST_VISIBLE_VALUE_REFRESH.md](notes/session/sensorlist/SESSION_NOTES_2026-03-08_SENSORLIST_VISIBLE_VALUE_REFRESH.md) | # Session Notes 2026-03-08 - SensorList Visible Value Refresh |
-
+| 2026-03-09 | session | sensorlist | release | [notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md) | # Session Notes 2026-03-09 - SensorList-v1.0.1 Release |

--- a/deslopification/memory/notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md
+++ b/deslopification/memory/notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md
@@ -1,0 +1,56 @@
+# Session Notes 2026-03-09 - SensorList-v1.0.1 Release
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `sensorlist`
+- Concern: `release`
+- Store this file under:
+  - `deslopification/memory/notes/{artifact}/{scope}/`
+
+## What changed
+
+- Released the `SensorList` script artifact at `1.0.1`.
+- Added a script-scoped `CHANGELOG.md` entry for `SensorList v1.0.1` anchored on Issue #14 and explicitly including the Issue #58 visible-value refresh stabilization.
+- Rebuilt the script artifact from the release branch for publication:
+  - `dist/SensorList-1.0.1.zip`
+- Generated standalone release notes for GitHub publication with `tools/write_release_notes.py`.
+- Files touched:
+  - `CHANGELOG.md`
+  - `deslopification/memory/notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md`
+
+## Why
+
+- Root cause or objective:
+  - Publish the deferred `SensorList v1.0.1` script release with correct changelog metadata, validated packaging, and a GitHub release body sourced directly from `CHANGELOG.md`.
+- Scope guardrails:
+  - Root repository version remained `1.0.3`.
+  - No repository-wide release policy changed.
+
+## Validation run(s)
+
+- `python tools/session_preflight.py --mode issue --issue-number 14 --issue-kind enhancement --slug sensor-values-column --release-kind script --project SensorList --script-gate-issue 32`
+  - result: `PASS_WITH_WARNING` on `release/SensorList-v1.0.1` (release branch differs from the recommended issue branch)
+- `luac -p scripts/SensorList/main.lua`
+  - result: passed
+- `python -m pytest tests/test_sensorlist_widget.py -q`
+  - result: `6 passed`
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
+  - result: `95 passed, 14 skipped`
+- `python tools/build.py --project SensorList --dist`
+  - result: passed
+  - artifact: `dist/SensorList-1.0.1.zip`
+- `python tools/write_release_notes.py --version 1.0.1 --project SensorList --output .tmp/release-notes-SensorList-v1.0.1.md`
+  - result: passed
+  - artifact: `.tmp/release-notes-SensorList-v1.0.1.md`
+
+## Follow-up items
+
+- Publish tag `SensorList-v1.0.1` and GitHub release `SensorList-v1.0.1` with asset `dist/SensorList-1.0.1.zip`.
+- Verify the release metadata and record the published release URL.
+- Delete `release/SensorList-v1.0.1` after publication.
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: no
+- If `no`, reason: release execution only; no durable workflow or behavior policy changed.


### PR DESCRIPTION
## Summary
- add the SensorList v1.0.1 changelog entry
- record the script release session note and refresh the memory catalog
- prepare validated release metadata for publication

## Validation
- python tools/session_preflight.py --mode issue --issue-number 14 --issue-kind enhancement --slug sensor-values-column --release-kind script --project SensorList --script-gate-issue 32
- luac -p scripts/SensorList/main.lua
- python -m pytest tests/test_sensorlist_widget.py -q
- python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q
- python tools/build.py --project SensorList --dist
- python tools/write_release_notes.py --version 1.0.1 --project SensorList --output .tmp/release-notes-SensorList-v1.0.1.md