### PR TITLE
Add README download links for latest script releases and enforce with docs contract test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@
 - If a change touches `README.md`, `docs/`, or other contributor-facing docs, run:
   `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
 - Docs updates are not complete until docs contract checks pass.
+- Keep `README.md` 'Download Latest Script Releases' links aligned with the latest published script release ZIP assets whenever a script release is published.
 - Include the docs validation command output in the PR `Verification` checklist.
 - If workflow/behavior changed, add a session note under
   `deslopification/memory/notes/{artifact}/{scope}/`, regenerate

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Ethos Lua widget workspace. Current active project: `SensorList`.
 - Packaging flow produces Ethos-installable ZIP archives.
 - Manual list scrolling is implemented via wheel/button events.
 
+## Download Latest Script Releases
+
+- [Download SensorList (v1.0.1)](https://github.com/doppleganger53/sloppy-ethos/releases/download/SensorList-v1.0.1/SensorList-1.0.1.zip)
+- [Download ethos_events (v0.1.0)](https://github.com/doppleganger53/sloppy-ethos/releases/download/ethos_events-v0.1.0/ethos_events-0.1.0.zip)
+
+
 ## Visual Overview
 
 Visual onboarding media is intentionally placeholder-only for now. A screenshot

--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,17 +15,17 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-- Files: 103
-- Total size: 169,688 bytes
-- Total lines: 4,550
+- Files: 105
+- Total size: 172,227 bytes
+- Total lines: 4,629
 - Distribution by artifact:
-  - session notes: 97
+  - session notes: 99
   - handoff/restart notes: 3
   - reference notes: 2
   - summary notes: 1
 
 - Distribution by scope:
-  - 57 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
+  - 59 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
   - 17 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
   - 15 -- memory ( Memory system structure and retrieval policy )
   - 7 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
@@ -37,7 +37,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
   - 24 -- implementation
   - 15 -- release
   - 11 -- build
-  - 9 -- docs
+  - 11 -- docs
   - 6 -- testing
   - 5 -- issue-admin
   - 5 -- prompts
@@ -47,6 +47,8 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 
 - Selection: newest session notes where `Concern` is one of `build`, `docs`, `metadata`, `release`, `testing`, or `workflow`; keep up to 3 per concern, then keep newest 12 overall.
 - 2026-03-09 | release | sensorlist | [notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md) | # Session Notes 2026-03-09 - SensorList-v1.0.1 Release
+- 2026-03-09 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md](notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md) | # Session Notes 2026-03-09 - Issue #62 README Guidance Relocation
+- 2026-03-09 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_DOWNLOAD_LINKS.md](notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_DOWNLOAD_LINKS.md) | # Session Notes 2026-03-09 - Issue #62 README Download Links
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md](notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md) | # Session Notes 2026-03-08 - VS Code Lua Coverage Workflow
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md](notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md) | # Session Notes 2026-03-08 - Debug Sessions Require Deploy
 - 2026-03-08 | build | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_BUILD_CLEAN_ORDER_FIX.md](notes/session/repo/SESSION_NOTES_2026-03-08_BUILD_CLEAN_ORDER_FIX.md) | # Session Notes 2026-03-08 - Build Clean Order Fix
@@ -56,8 +58,6 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 - 2026-03-02 | release | repo | [notes/session/repo/SESSION_NOTES_2026-03-02_REPO_RELEASE_CONSOLIDATED_BUNDLE_ONLY.md](notes/session/repo/SESSION_NOTES_2026-03-02_REPO_RELEASE_CONSOLIDATED_BUNDLE_ONLY.md) | # Session Notes 2026-03-02 - Repo Releases Consolidated Bundle Only
 - 2026-03-02 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-03-02_GOOD_FIRST_ISSUE_GUIDANCE_REMOVAL.md](notes/session/repo/SESSION_NOTES_2026-03-02_GOOD_FIRST_ISSUE_GUIDANCE_REMOVAL.md) | # Session Notes 2026-03-02 - Contributing Good First Issue Guidance Removal
 - 2026-02-27 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_SESSION_PREFLIGHT_TEST_COVERAGE.md](notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_SESSION_PREFLIGHT_TEST_COVERAGE.md) | # Session Notes 2026-02-27 - Issue #16 session_preflight test coverage
-- 2026-02-27 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md](notes/session/repo/SESSION_NOTES_2026-02-27_ISSUE_16_CATALOG_TEST_PORTABILITY.md) | # Session Notes 2026-02-27 - Issue #16 Catalog Test Portability
-- 2026-02-26 | metadata | repo | [notes/session/repo/SESSION_NOTES_2026-02-26_REPO_METADATA_DESCRIPTION_TOPICS.md](notes/session/repo/SESSION_NOTES_2026-02-26_REPO_METADATA_DESCRIPTION_TOPICS.md) | # Session Notes 2026-02-26 - Repository Metadata Description and Topics
 
 ## Recent Ethos Platform Notes
 
@@ -175,4 +175,6 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-03-08 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md](notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md) | # Session Notes 2026-03-08 - Debug Sessions Require Deploy |
 | 2026-03-08 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md](notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md) | # Session Notes 2026-03-08 - VS Code Lua Coverage Workflow |
 | 2026-03-08 | session | sensorlist | implementation | [notes/session/sensorlist/SESSION_NOTES_2026-03-08_SENSORLIST_VISIBLE_VALUE_REFRESH.md](notes/session/sensorlist/SESSION_NOTES_2026-03-08_SENSORLIST_VISIBLE_VALUE_REFRESH.md) | # Session Notes 2026-03-08 - SensorList Visible Value Refresh |
+| 2026-03-09 | session | repo | docs | [notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_DOWNLOAD_LINKS.md](notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_DOWNLOAD_LINKS.md) | # Session Notes 2026-03-09 - Issue #62 README Download Links |
+| 2026-03-09 | session | repo | docs | [notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md](notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md) | # Session Notes 2026-03-09 - Issue #62 README Guidance Relocation |
 | 2026-03-09 | session | sensorlist | release | [notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md) | # Session Notes 2026-03-09 - SensorList-v1.0.1 Release |

--- a/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_DOWNLOAD_LINKS.md
+++ b/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_DOWNLOAD_LINKS.md
@@ -1,0 +1,41 @@
+# Session Notes 2026-03-09 - Issue #62 README Download Links
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `repo`
+- Concern: `docs`
+- Store this file under:
+  - `deslopification/memory/notes/{artifact}/{scope}/`
+
+## What changed
+
+- Added a new README section near the top: `Download Latest Script Releases`.
+- Added direct GitHub release download links for the current latest script ZIP assets:
+  - `SensorList-1.0.1.zip`
+  - `ethos_events-0.1.0.zip`
+- Added a docs contract test that enforces README download links include each script project's latest versioned ZIP filename from `scripts/{ProjectName}/VERSION`.
+- Files touched:
+  - `README.md`
+  - `tests/test_docs_contracts.py`
+
+## Why
+
+- Root cause or objective:
+  - Issue #62 requested easy single-click download links for casual users and a workflow guard so links are updated with new script releases.
+- Scope guardrails:
+  - Kept changes focused to README docs plus docs contract validation coverage only.
+
+## Validation run(s)
+
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
+  - result: pass (`97 passed, 15 skipped`)
+
+## Follow-up items
+
+- none
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: `no`
+- If `no`, reason: not a durable workflow/behavior policy change; this is an issue-scoped docs update with test coverage.

--- a/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md
+++ b/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md
@@ -1,0 +1,38 @@
+# Session Notes 2026-03-09 - Issue #62 README Guidance Relocation
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `repo`
+- Concern: `docs`
+- Store this file under:
+  - `deslopification/memory/notes/{artifact}/{scope}/`
+
+## What changed
+
+- Removed contributor-maintenance guidance text from `README.md` download section to keep user-facing docs concise.
+- Added equivalent maintenance guidance to `CONTRIBUTING.md` so release-link upkeep instructions live in contributor policy docs instead of end-user README content.
+- Files touched:
+  - `README.md`
+  - `CONTRIBUTING.md`
+
+## Why
+
+- Root cause or objective:
+  - Follow-up request on issue #62 asked to keep process guidance out of README and place it in contributor/agent workflow docs.
+- Scope guardrails:
+  - Limited changes to documentation wording and did not alter release links or test logic.
+
+## Validation run(s)
+
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
+  - result: pass (`97 passed, 15 skipped`)
+
+## Follow-up items
+
+- none
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: `no`
+- If `no`, reason: no durable workflow policy change; this is placement refinement for existing issue-specific docs guidance.

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -162,6 +162,23 @@ def test_vscode_pytest_enabled_in_repo_settings():
     assert settings.get("python.testing.pytestEnabled") is True
 
 
+
+
+def test_readme_download_links_match_script_versions():
+    readme_text = _read(README_PATH)
+    assert "## Download Latest Script Releases" in readme_text
+
+    scripts_root = REPO_ROOT / "scripts"
+    for project_dir in scripts_root.iterdir():
+        if not project_dir.is_dir():
+            continue
+        project_name = project_dir.name
+        version = (project_dir / "VERSION").read_text(encoding="utf-8").strip()
+        expected_asset = f"{project_name}-{version}.zip"
+        assert expected_asset in readme_text, (
+            f"README download links must include latest {project_name} asset {expected_asset}."
+        )
+        assert "/releases/download/" in readme_text
 def test_required_recommended_links_present_in_readme():
     readme_text = _read(README_PATH)
     links = set(_extract_markdown_links(readme_text))


### PR DESCRIPTION
### Motivation

- Provide easy single-click download links to the latest published script ZIP assets for casual users.
- Move contributor-maintenance guidance out of user-facing README into `CONTRIBUTING.md` to keep README concise.
- Ensure README release links are kept up-to-date automatically by adding a docs contract test that checks `scripts/{ProjectName}/VERSION` values.

### Description

- Added a new `## Download Latest Script Releases` section to `README.md` with direct links to `SensorList-1.0.1.zip` and `ethos_events-0.1.0.zip` release assets.
- Relocated maintenance guidance about keeping README download links aligned with published releases from `README.md` into `CONTRIBUTING.md`.
- Added `test_readme_download_links_match_script_versions` to `tests/test_docs_contracts.py` which iterates `scripts/*/VERSION` and asserts the corresponding `{project}-{version}.zip` asset and `/releases/download/` appear in the README.
- Updated memory/session notes and regenerated `deslopification/memory/CATALOG.md` counts to reflect the new session notes files describing these docs changes.

### Testing

- Ran `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q` and the run passed with `97 passed, 15 skipped`.
- The added contract test `test_readme_download_links_match_script_versions` executed as part of the docs contract tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee7f56aec8333b3ccff553a201f6a)