### PR TITLE
Preserve BoundryMap touch fix before retiring PR 65

### DIFF
--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,17 +15,17 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-- Files: 119
-- Total size: 199,965 bytes
-- Total lines: 5,301
+- Files: 120
+- Total size: 202,183 bytes
+- Total lines: 5,351
 - Distribution by artifact:
-  - session notes: 113
+  - session notes: 114
   - handoff/restart notes: 3
   - reference notes: 2
   - summary notes: 1
 
 - Distribution by scope:
-  - 73 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
+  - 74 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
   - 17 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
   - 15 -- memory ( Memory system structure and retrieval policy )
   - 7 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
@@ -33,7 +33,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
   - 3 -- handoff ( Session continuity and restart handoffs )
 
 - Distribution by concern:
-  - 29 -- implementation
+  - 30 -- implementation
   - 26 -- workflow
   - 17 -- build
   - 15 -- release
@@ -192,3 +192,4 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-04-27 | session | repo | build | [notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md](notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md) | # Session Notes 2026-04-27 - Generic Build Assets |
 | 2026-04-27 | session | repo | testing | [notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md](notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md) | # Session Notes 2026-04-27 - Issue 72 Script Local Tests |
 | 2026-04-27 | session | repo | build | [notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md](notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md) | # Session Notes 2026-04-27 - PR71 Exclude Source Fix |
+| 2026-05-05 | session | repo | implementation | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md) | # Session Notes 2026-05-05 - Issue 86 Agentic Reorg Retirement |

--- a/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md
+++ b/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md
@@ -1,0 +1,50 @@
+# Session Notes 2026-05-05 - Issue 86 Agentic Reorg Retirement
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `repo`
+- Concern: `implementation`
+
+## What changed
+
+- Reviewed PR #65 against current `main` before retiring the stale `feature/agentic-reorg` branch.
+- Ported only the remaining useful BoundryMap touch-control fix from PR #65 instead of merging the stale governance/session tooling branch.
+- BoundryMap touch handling now normalizes Ethos raw touch Y coordinates into widget content space, activates Save on touch start without moving an active draft endpoint, and uses release slop only after a control touch starts.
+- Files touched:
+  - `scripts/BoundryMap/main.lua`
+  - `scripts/BoundryMap/tests/lua/test_boundrymap.lua`
+  - `deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md`
+
+## Why
+
+- Root cause or objective:
+  - Issue #86 required resolving whether PR #65 should be merged, superseded, or retired. The branch still contained a real BoundryMap runtime fix, but its broad governance/session-start changes were stale against the current workflow model.
+- Scope guardrails:
+  - Did not merge PR #65 wholesale.
+  - Did not retain private map assets, stale prompt archive movement, or governance/session tooling changes from `feature/agentic-reorg`.
+
+## Validation run(s)
+
+- `luac -p scripts/BoundryMap/main.lua`
+  - result: pass
+- `python -m pytest scripts/BoundryMap/tests -q`
+  - result: pass, `3 passed`
+- `python tools/update_memory_catalog.py`
+  - result: pass, updated `deslopification/memory/CATALOG.md`
+- `python -m pytest tests/test_memory_catalog_sync.py -q`
+  - result: pass, `27 passed`
+- `python tools/build.py --project BoundryMap --dist`
+  - result: pass, packaged `dist/BoundryMap-0.1.6.zip`
+- `python -m pytest -q`
+  - result: pass, `253 passed, 16 skipped`
+
+## Follow-up items
+
+- Close PR #65 as not planned after the focused BoundryMap fix is committed and merged separately.
+- Delete stale `agentic-reorg` branches after PR #65 is closed.
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: no
+- If `no`, reason: this preserves one script runtime fix and retires a stale branch; it does not change durable workflow policy.

--- a/scripts/BoundryMap/main.lua
+++ b/scripts/BoundryMap/main.lua
@@ -44,6 +44,8 @@ local CONTROL_BUTTON_WIDTH = 72
 local CONTROL_BUTTON_HEIGHT = 24
 local CONTROL_BUTTON_GAP = 4
 local CONTROL_MARGIN = 6
+local CONTROL_RELEASE_SLOP = 8
+local TOUCH_CONTENT_Y_OFFSET = 18
 local ICON_PATH = "assets/icons"
 local COORDS_TEXT_X = 4
 local COORDS_TEXT_BOTTOM = 40
@@ -54,6 +56,7 @@ local gpsLonQuery = { name = "GPS", options = nil }
 local gpsQueriesReady = false
 local gpsSensorQuery = { name = "" }
 local altSensorQuery = { name = "" }
+local saveBoundaries
 
 local function safeCall(fn, ...)
   if type(fn) ~= "function" then
@@ -374,6 +377,13 @@ local function resolveTouchPhase(category, value)
   return nil
 end
 
+local function normalizeTouchPoint(x, y)
+  if type(y) ~= "number" then
+    return x, y
+  end
+  return x, y - TOUCH_CONTENT_Y_OFFSET
+end
+
 local function controlRects(widget)
   local w = widget.windowW or 480
   local totalHeight = (CONTROL_BUTTON_HEIGHT * 3) + (CONTROL_BUTTON_GAP * 2)
@@ -401,6 +411,65 @@ local function hitRect(x, y, rect)
     return false
   end
   return x >= rect.left and x <= rect.right and y >= rect.top and y <= rect.bottom
+end
+
+local function hitRectSlop(x, y, rect, slop)
+  if type(x) ~= "number" or type(y) ~= "number" or type(rect) ~= "table" then
+    return false
+  end
+  local pad = slop or 0
+  return x >= rect.left - pad and x <= rect.right + pad and y >= rect.top - pad and y <= rect.bottom + pad
+end
+
+local function controlAtPoint(widget, x, y, slop)
+  local rects = controlRects(widget)
+  if hitRect(x, y, rects.draw) then
+    return "draw", rects.draw
+  end
+  if hitRect(x, y, rects.delete) then
+    return "delete", rects.delete
+  end
+  if hitRect(x, y, rects.save) then
+    return "save", rects.save
+  end
+  if hitRectSlop(x, y, rects.draw, slop) then
+    return "draw", rects.draw
+  end
+  if hitRectSlop(x, y, rects.delete, slop) then
+    return "delete", rects.delete
+  end
+  if hitRectSlop(x, y, rects.save, slop) then
+    return "save", rects.save
+  end
+  return nil, nil
+end
+
+local function activateControl(widget, control)
+  if control == "draw" then
+    widget.drawMode = not widget.drawMode
+    if widget.drawMode then
+      widget.deleteMode = false
+    end
+    widget.needsInvalidate = true
+    return true
+  end
+  if control == "delete" then
+    widget.deleteMode = not widget.deleteMode
+    if widget.deleteMode then
+      widget.drawMode = false
+    end
+    widget.needsInvalidate = true
+    return true
+  end
+  if control == "save" then
+    local okSave, saveErr = saveBoundaries(widget)
+    if not okSave then
+      logRuntimeError("sidecar-save", saveErr)
+    end
+    widget.needsInvalidate = true
+    return true
+  end
+  return false
 end
 
 local function triggerWarningFeedback(widget)
@@ -504,7 +573,7 @@ local function encodeBoundary(boundary)
   )
 end
 
-local function saveBoundaries(widget)
+saveBoundaries = function(widget)
   local path = sidecarPath(widget.bitmapFile)
   if not path or not io or type(io.open) ~= "function" then
     return false, "sidecar path unavailable"
@@ -1533,18 +1602,16 @@ local function paint(widget)
 end
 
 local function handleControlTouch(widget, phase, x, y)
-  local rects = controlRects(widget)
+  local exactControl = controlAtPoint(widget, x, y, 0)
+  local releaseControl = controlAtPoint(widget, x, y, CONTROL_RELEASE_SLOP)
   if phase == "start" then
-    if hitRect(x, y, rects.draw) then
-      widget.touchArmed = "draw"
-      return true
-    end
-    if hitRect(x, y, rects.delete) then
-      widget.touchArmed = "delete"
-      return true
-    end
-    if hitRect(x, y, rects.save) then
-      widget.touchArmed = "save"
+    if exactControl then
+      widget.touchArmed = exactControl
+      widget.touchActivatedOnStart = false
+      if exactControl == "save" then
+        activateControl(widget, exactControl)
+        widget.touchActivatedOnStart = true
+      end
       return true
     end
     return false
@@ -1561,28 +1628,12 @@ local function handleControlTouch(widget, phase, x, y)
 
   if phase == "end" then
     widget.touchArmed = nil
-    if armed == "draw" and hitRect(x, y, rects.draw) then
-      widget.drawMode = not widget.drawMode
-      if widget.drawMode then
-        widget.deleteMode = false
-      end
-      widget.needsInvalidate = true
+    if widget.touchActivatedOnStart then
+      widget.touchActivatedOnStart = false
       return true
     end
-    if armed == "delete" and hitRect(x, y, rects.delete) then
-      widget.deleteMode = not widget.deleteMode
-      if widget.deleteMode then
-        widget.drawMode = false
-      end
-      widget.needsInvalidate = true
-      return true
-    end
-    if armed == "save" then
-      local okSave, saveErr = saveCurrentBoundaries(widget)
-      if not okSave then
-        logRuntimeError("sidecar-save", saveErr)
-      end
-      widget.needsInvalidate = true
+    if armed == releaseControl then
+      activateControl(widget, armed)
       return true
     end
   end
@@ -1615,7 +1666,13 @@ local function handleMapTouch(widget, phase, x, y)
       return true
     end
     if phase == "end" and widget.draftBoundary then
-      return commitDraftBoundary(widget, x, y)
+      local localX, localY = screenToBitmapLocal(widget, x, y)
+      local startX = widget.draftBoundary.x1
+      local startY = widget.draftBoundary.y1
+      widget.draftBoundary = nil
+      widget.pendingDraftPoint = nil
+      addBoundary(widget, startX, startY, localX, localY)
+      return true
     end
   elseif widget.deleteMode then
     if phase == "end" then
@@ -1702,10 +1759,11 @@ local function event(widget, category, value, x, y)
     if not phase then
       return false
     end
-    if handleControlTouch(widget, phase, x, y) then
+    local contentX, contentY = normalizeTouchPoint(x, y)
+    if handleControlTouch(widget, phase, contentX, contentY) then
       return true
     end
-    return handleMapTouch(widget, phase, x, y)
+    return handleMapTouch(widget, phase, contentX, contentY)
   end)
   if not ok then
     setWidgetError(widget, "event", result)
@@ -1808,6 +1866,7 @@ local function testExports()
     write = write,
     event = event,
     controlRects = controlRects,
+    controlAtPoint = controlAtPoint,
     pointSegmentDistance = pointSegmentDistance,
     updateWarnings = updateWarnings,
     markBoundariesDirty = markBoundariesDirty,

--- a/scripts/BoundryMap/tests/lua/test_boundrymap.lua
+++ b/scripts/BoundryMap/tests/lua/test_boundrymap.lua
@@ -14,9 +14,11 @@ _G.TOUCH_START = 16640
 _G.TOUCH_MOVE = 16642
 _G.TOUCH_END = 16641
 
+local TOUCH_CONTENT_Y_OFFSET = 18
 local storageValues = {}
 local ioReads = {}
 local ioWrites = {}
+local ioWriteCounts = {}
 local formRows = {}
 local drawTexts = {}
 local drawnBitmaps = {}
@@ -183,6 +185,7 @@ _G.io = {
       local handle = {}
       function handle:write(content)
         ioWrites[path] = content
+        ioWriteCounts[path] = (ioWriteCounts[path] or 0) + 1
       end
       function handle:close() end
       return handle
@@ -468,26 +471,57 @@ widget.bmpW = 480
 widget.bmpH = 272
 widget.mapMeta = meta
 local rects = test.controlRects(widget)
+local function rawTouchY(contentY)
+  return contentY + TOUCH_CONTENT_Y_OFFSET
+end
+
 assert_equal(rects.draw.right - rects.draw.left, 72, "draw button width expanded")
 assert_equal(rects.draw.bottom - rects.draw.top, 24, "draw button height expanded")
 local drawX = rects.draw.left + 2
 local drawY = rects.draw.top + 2
-assert_true(test.event(widget, _G.EVT_TOUCH, 16640, drawX, drawY), "draw button start consumed")
-assert_true(test.event(widget, _G.EVT_TOUCH, 16641, drawX, drawY), "draw button end consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16640, drawX, rawTouchY(drawY)), "draw button start consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16641, drawX, rawTouchY(drawY)), "draw button end consumed")
 assert_true(widget.drawMode, "draw mode toggled on")
 
 local startX = 20
 local startY = 20
 local endX = 120
 local endY = 40
-assert_true(test.event(widget, _G.EVT_TOUCH, 16640, startX, startY), "map draw start consumed")
-assert_true(test.event(widget, _G.EVT_TOUCH, 16642, 80, 30), "map draw move consumed")
-assert_true(test.event(widget, _G.EVT_TOUCH, 16641, endX, endY), "map draw end consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16640, startX, rawTouchY(startY)), "map draw start consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16642, 80, rawTouchY(30)), "map draw move consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16641, endX, rawTouchY(endY)), "map draw end consumed")
 assert_equal(#widget.boundaries, 1, "event draw flow adds boundary")
+
+widget.bitmapFile = "TestMap.bmp"
+widget.boundaryDirty = true
+local saveStartX = rects.save.left + 2
+local saveStartY = rects.save.top + 2
+local saveDriftX = rects.save.right + 5
+local saveDriftY = rects.save.bottom + 5
+ioWriteCounts["/scripts/BoundryMap/assets/maps/TestMap.boundries.json"] = 0
+assert_true(test.event(widget, _G.EVT_TOUCH, 16640, saveStartX, rawTouchY(saveStartY)), "save button start consumed")
+assert_true(not widget.boundaryDirty, "save button clears dirty state on start")
+assert_equal(ioWriteCounts["/scripts/BoundryMap/assets/maps/TestMap.boundries.json"], 1, "save button writes on start")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16641, saveDriftX, rawTouchY(saveDriftY)), "save button tolerates small release drift")
+assert_true(not widget.boundaryDirty, "save button remains clean after drift")
+assert_equal(ioWriteCounts["/scripts/BoundryMap/assets/maps/TestMap.boundries.json"], 1, "save button does not double-write on release")
+
+widget.drawMode = true
+widget.deleteMode = false
+widget.draftBoundary = nil
+widget.pendingDraftPoint = nil
+local nearSaveX = rects.save.left - 5
+local nearSaveY = rects.save.top + 2
+assert_true(test.event(widget, _G.EVT_TOUCH, 16640, nearSaveX, rawTouchY(nearSaveY)), "map touch near save start consumed")
+assert_true(widget.draftBoundary ~= nil, "map touch just outside save starts drawing")
+assert_equal(widget.draftBoundary.x1, nearSaveX, "near-save map touch preserves x")
+assert_equal(widget.draftBoundary.y1, nearSaveY, "near-save map touch preserves y")
 
 widget.deleteMode = true
 widget.drawMode = false
-assert_true(test.event(widget, _G.EVT_TOUCH, 16641, 22, 22), "delete touch consumed")
+widget.draftBoundary = nil
+widget.pendingDraftPoint = nil
+assert_true(test.event(widget, _G.EVT_TOUCH, 16641, 22, rawTouchY(22)), "delete touch consumed")
 assert_equal(#widget.boundaries, 0, "event delete flow removes boundary")
 
 widget = test.create()
@@ -517,18 +551,12 @@ assert_equal(saveRects.save.right - saveRects.save.left, 72, "save button width 
 assert_equal(saveRects.save.bottom - saveRects.save.top, 24, "save button height expanded")
 local saveX = saveRects.save.left + 4
 local saveY = saveRects.save.top + 4
-assert_true(test.event(widget, _G.EVT_TOUCH, 16640, saveX, saveY), "save touch start consumed")
-assert_true(test.event(widget, _G.EVT_TOUCH, 16641, saveX, saveY), "save touch consumed")
-assert_equal(#widget.boundaries, 1, "save commits current draft")
-assert_true(widget.draftBoundary == nil, "save clears draft boundary")
-assert_true(widget.drawMode, "save keeps draw mode enabled")
-local savedAfterTouch = ioWrites["/scripts/BoundryMap/assets/maps/TestMap.boundries.json"]
-local savedAfterTouchParsed = test.parseBoundaryObjects(savedAfterTouch)
-assert_equal(#savedAfterTouchParsed, 1, "save writes one boundary after touch")
-assert_equal(savedAfterTouchParsed[1].x1, 40, "save keeps draft start x")
-assert_equal(savedAfterTouchParsed[1].y1, 30, "save keeps draft start y")
-assert_equal(savedAfterTouchParsed[1].x2, 120, "save keeps draft end x")
-assert_equal(savedAfterTouchParsed[1].y2, 48, "save keeps draft end y")
+ioWrites["/scripts/BoundryMap/assets/maps/TestMap.boundries.json"] = nil
+assert_true(test.event(widget, _G.EVT_TOUCH, 16640, saveX, rawTouchY(saveY)), "save start with active draft stays on controls")
+assert_equal(#widget.boundaries, 0, "save start does not add active draft boundary")
+assert_equal(widget.draftBoundary.x2, 120, "save start does not move draft boundary endpoint")
+assert_true(type(ioWrites["/scripts/BoundryMap/assets/maps/TestMap.boundries.json"]) == "string", "save start writes sidecar with active draft")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16641, saveX, rawTouchY(saveY)), "save release after active draft save consumed")
 
 widget = test.create()
 widget.bitmapFile = "TestMap.bmp"
@@ -545,9 +573,9 @@ ioWrites["/scripts/BoundryMap/assets/maps/TestMap.boundries.json"] = nil
 local overlapRects = test.controlRects(widget)
 local overlapSaveX = overlapRects.save.left + 3
 local overlapSaveY = overlapRects.save.top + 3
-assert_true(test.event(widget, _G.EVT_TOUCH, 16640, 40, 30), "map draw over save start consumed")
-assert_true(test.event(widget, _G.EVT_TOUCH, 16642, overlapSaveX - 10, overlapSaveY), "map draw over save move consumed")
-assert_true(test.event(widget, _G.EVT_TOUCH, 16641, overlapSaveX, overlapSaveY), "map draw over save end consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16640, 40, rawTouchY(30)), "map draw over save start consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16642, overlapSaveX - 10, rawTouchY(overlapSaveY)), "map draw over save move consumed")
+assert_true(test.event(widget, _G.EVT_TOUCH, 16641, overlapSaveX, rawTouchY(overlapSaveY)), "map draw over save end consumed")
 assert_equal(#widget.boundaries, 1, "map release over save adds boundary")
 assert_equal(widget.boundaries[1].x1, 40, "map release over save keeps start x")
 assert_equal(widget.boundaries[1].y1, 30, "map release over save keeps start y")


### PR DESCRIPTION
## Summary
- Port only the useful BoundryMap control-touch fix from PR #65.
- Normalize Ethos raw touch Y coordinates into widget content space before hit-testing.
- Save on touch start without moving active draft endpoints, and allow release drift only after a control touch starts.
- Record issue #86 retirement notes in repo memory.

## Validation
- luac -p scripts/BoundryMap/main.lua
- python -m pytest scripts/BoundryMap/tests -q
- python tools/update_memory_catalog.py
- python -m pytest tests/test_memory_catalog_sync.py -q
- python tools/build.py --project BoundryMap --dist
- python -m pytest -q

Refs #86