### PR TITLE
chore: add Ethos 26.1 compatibility baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ To build a single install ZIP with multiple scripts:
 - `tools/create_todo_issues.py`: GitHub issue bootstrap for TODO backlog tracking
 - `deslopification/prompts/done/SensorList.md`: original implementation prompt
 - `docs/`: development notes and handoff documents
+- [docs/ETHOS_26_1_COMPATIBILITY.md](docs/ETHOS_26_1_COMPATIBILITY.md): Ethos
+  `26.1` reference checkout, validation targets, and compatibility matrix
 - `docs/REPOSITORY_LAYOUT.md`: reference for `tools/`, repo-level `tests/`, script-local tests, `deslopification/`, and root artifacts
 - [docs/SensorList/SENSORLIST_ARCHITECTURE.md](docs/SensorList/SENSORLIST_ARCHITECTURE.md): SensorList lifecycle/state flow reference
 

--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,17 +15,17 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-- Files: 120
-- Total size: 202,183 bytes
-- Total lines: 5,351
+- Files: 121
+- Total size: 204,255 bytes
+- Total lines: 5,410
 - Distribution by artifact:
-  - session notes: 114
+  - session notes: 115
   - handoff/restart notes: 3
   - reference notes: 2
   - summary notes: 1
 
 - Distribution by scope:
-  - 74 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
+  - 75 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
   - 17 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
   - 15 -- memory ( Memory system structure and retrieval policy )
   - 7 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
@@ -37,7 +37,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
   - 26 -- workflow
   - 17 -- build
   - 15 -- release
-  - 13 -- docs
+  - 14 -- docs
   - 7 -- testing
   - 5 -- issue-admin
   - 5 -- prompts
@@ -46,6 +46,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 ## Recent High-Signal Notes (Auto-generated)
 
 - Selection: newest session notes where `Concern` is one of `build`, `docs`, `metadata`, `release`, `testing`, or `workflow`; keep up to 3 per concern, then keep newest 12 overall.
+- 2026-05-05 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md) | # Session Notes 2026-05-05 - Issue #76 Ethos 26.1 Baseline
 - 2026-04-27 | build | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md](notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md) | # Session Notes 2026-04-27 - PR71 Exclude Source Fix
 - 2026-04-27 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md](notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md) | # Session Notes 2026-04-27 - Issue 72 Script Local Tests
 - 2026-04-27 | build | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md](notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md) | # Session Notes 2026-04-27 - Generic Build Assets
@@ -53,7 +54,6 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 - 2026-03-28 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-03-28_README_PUBLISHED_SCRIPT_LINK_POLICY.md](notes/session/repo/SESSION_NOTES_2026-03-28_README_PUBLISHED_SCRIPT_LINK_POLICY.md) | # Session Notes 2026-03-28 - README Published Script Link Policy
 - 2026-03-28 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-03-28_BOUNDRYMAP_LICENSE_DERIVATION.md](notes/session/repo/SESSION_NOTES_2026-03-28_BOUNDRYMAP_LICENSE_DERIVATION.md) | # Session Notes 2026-03-28 - BoundryMap License Derivation Notice
 - 2026-03-09 | release | sensorlist | [notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md) | # Session Notes 2026-03-09 - SensorList-v1.0.1 Release
-- 2026-03-09 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md](notes/session/repo/SESSION_NOTES_2026-03-09_ISSUE_62_README_GUIDANCE_RELOCATION.md) | # Session Notes 2026-03-09 - Issue #62 README Guidance Relocation
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md](notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md) | # Session Notes 2026-03-08 - VS Code Lua Coverage Workflow
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md](notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md) | # Session Notes 2026-03-08 - Debug Sessions Require Deploy
 - 2026-03-05 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md) | # Session Notes 2026-03-05 - Issue #56 Mutable Workflow Agent Metadata
@@ -192,4 +192,5 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-04-27 | session | repo | build | [notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md](notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md) | # Session Notes 2026-04-27 - Generic Build Assets |
 | 2026-04-27 | session | repo | testing | [notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md](notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md) | # Session Notes 2026-04-27 - Issue 72 Script Local Tests |
 | 2026-04-27 | session | repo | build | [notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md](notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md) | # Session Notes 2026-04-27 - PR71 Exclude Source Fix |
+| 2026-05-05 | session | repo | docs | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md) | # Session Notes 2026-05-05 - Issue #76 Ethos 26.1 Baseline |
 | 2026-05-05 | session | repo | implementation | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md) | # Session Notes 2026-05-05 - Issue 86 Agentic Reorg Retirement |

--- a/deslopification/memory/CURRENT_STATE.md
+++ b/deslopification/memory/CURRENT_STATE.md
@@ -1,4 +1,4 @@
-# Current State (2026-03-02)
+# Current State (2026-05-05)
 
 This file is the high-signal memory entrypoint for cold-start sessions.
 Historical detail remains in individual session notes referenced from
@@ -83,6 +83,9 @@ Historical detail remains in individual session notes referenced from
 - Script-owned tests live under `scripts/{ProjectName}/tests/` and are
   included in repo-root pytest discovery through `pytest.ini`; install staging
   excludes script-local `tests/` folders from ZIP and simulator payloads.
+- Ethos `26.1` compatibility baseline, reference checkout path, simulator
+  targets, and follow-up issue map now live in
+  `docs/ETHOS_26_1_COMPATIBILITY.md`.
 
 ## Active Tooling Decisions
 

--- a/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md
+++ b/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md
@@ -1,0 +1,59 @@
+# Session Notes 2026-05-05 - Issue #76 Ethos 26.1 Baseline
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `repo`
+- Concern: `docs`
+- Store this file under:
+  - `deslopification/memory/notes/{artifact}/{scope}/`
+
+## What changed
+
+- Added `docs/ETHOS_26_1_COMPATIBILITY.md` as the repo-level baseline for the
+  checked `ETHOS-Feedback-Community` `26.1` reference checkout, simulator
+  validation targets, and the current compatibility matrix.
+- Linked the new baseline doc from `README.md`, `docs/DEVELOPMENT.md`, and
+  `docs/REPOSITORY_LAYOUT.md`.
+- Extended docs tests so the baseline doc is required, linked, and checked for
+  the core `26.1` reference facts and follow-up issue links.
+- Updated `deslopification/memory/CURRENT_STATE.md` to point future sessions at
+  the new compatibility baseline doc.
+- Files touched:
+  - `docs/ETHOS_26_1_COMPATIBILITY.md`
+  - `README.md`
+  - `docs/DEVELOPMENT.md`
+  - `docs/REPOSITORY_LAYOUT.md`
+  - `tests/test_docs_commands.py`
+  - `tests/test_docs_contracts.py`
+  - `deslopification/memory/CATALOG.md`
+  - `deslopification/memory/CURRENT_STATE.md`
+
+## Why
+
+- Root cause or objective:
+  - Issue `#76` required a durable, reproducible Ethos `26.1` baseline that
+    future compatibility work can reference without repeating the initial repo
+    and issue triage.
+- Scope guardrails:
+  - Kept the change focused on the baseline documentation, docs tests, and
+    memory sync.
+  - Left script inventory cleanup and downstream compatibility fixes to their
+    follow-up issues instead of expanding this issue into implementation work.
+
+## Validation run(s)
+
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
+  - result: pass (`143 passed, 17 skipped`)
+- `python tools/update_memory_catalog.py`
+  - result: pass (`Updated deslopification/memory/CATALOG.md`)
+
+## Follow-up items
+
+- Close or continue the downstream compatibility issues as each script or API
+  probe is implemented, starting with `#77`, `#78`, `#79`, `#80`, `#81`, and
+  `#82`.
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: yes

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -65,6 +65,8 @@
 
 - Issue #22 build tooling evaluation: [Issue #22 build.py to doit migration decision](decisions/ISSUE-022-doit-migration-evaluation.md).
 - Current decision state (2026-02-26): retain `tools/build.py` as the canonical build/deploy workflow.
+- Ethos `26.1` reference baseline and compatibility backlog:
+  [ETHOS_26_1_COMPATIBILITY.md](ETHOS_26_1_COMPATIBILITY.md).
 
 ## Session Memory Navigation
 

--- a/docs/ETHOS_26_1_COMPATIBILITY.md
+++ b/docs/ETHOS_26_1_COMPATIBILITY.md
@@ -1,0 +1,100 @@
+# Ethos 26.1 Compatibility Baseline
+
+This document is the repository's working baseline for Ethos `26.1`
+compatibility checks. It records the exact reference checkout, the simulator
+targets to use for repeatable validation, and the currently known upgrade risks
+across the repo.
+
+## Reference Checkout
+
+- Repository:
+  `https://github.com/FrSkyRC/ETHOS-Feedback-Community.git`
+- Local path: `..\ETHOS-Feedback-Community`
+- Resolved Windows path:
+  `C:\Users\kurtk\Documents\Workspaces\EthosLua\ETHOS-Feedback-Community`
+- Branch: `26.1`
+- Commit: `e9d7afb7`
+- Baseline rule:
+  the original request mentioned Ethos `21.1`, but the concrete checked and
+  requested reference branch was `26.1`. Keep `26.1` as the evidence source
+  unless a later issue explicitly changes the target version.
+
+## Recreate Or Refresh
+
+```powershell
+git clone --branch 26.1 --single-branch https://github.com/FrSkyRC/ETHOS-Feedback-Community.git ..\ETHOS-Feedback-Community
+git -C ..\ETHOS-Feedback-Community fetch origin 26.1 --depth 1
+git -C ..\ETHOS-Feedback-Community checkout 26.1
+git -C ..\ETHOS-Feedback-Community pull --ff-only origin 26.1
+git -C ..\ETHOS-Feedback-Community rev-parse --short HEAD
+```
+
+Use the clone command when the reference checkout is missing. Use the
+fetch/checkout/pull sequence when the repo already exists and you want to
+confirm that it is still pinned to the tracked `26.1` branch.
+
+## Validation Targets
+
+- Reference API and example surface: the `26.1` checkout above.
+- Simulator radios:
+  `X20RS` primary, `X20S` secondary.
+- Local simulator paths stay private in `tools/deploy.config.json`; only the
+  radio keys belong in committed docs.
+- Debugging sessions with Lua behavior changes must deploy the touched script to
+  the simulator before closeout, using
+  `python tools/build.py --project {ProjectName} --deploy` and `--sim-radio X20S`
+  when reproducing `X20S`-specific behavior.
+- Treat simulator results as the default reproducible baseline, but require
+  physical-radio confirmation for issues that depend on touch events, icon
+  loading, or source-handle behavior that may diverge from the simulator.
+
+## Observed 26.1 Reference Patterns
+
+- Widget registration: `system.registerWidget(...)`
+- System tools and background tasks:
+  `system.registerSystemTool(...)`, `system.registerTask(...)`
+- Form fields seen in reference examples:
+  `form.addSensorField(...)`, `form.addChoiceField(...)`,
+  `form.addNumberField(...)`, `form.addTextButton(...)`,
+  `form.addStaticText(...)`
+- Bitmap loading patterns: `lcd.loadMask(...)`, `lcd.loadBitmap(...)`
+- Sensor/source access patterns:
+  `system.getSource(...)`, then `source:value(...)` or
+  `source:stringValue(...)`
+- Model surfaces confirmed during triage:
+  `model.createMix(...)`, `model.name()`
+
+## Compatibility Matrix
+
+| Area | Status | Current 26.1 risk | Validation target | Follow-up |
+| --- | --- | --- | --- | --- |
+| Shared Lua API stubs | Baseline defined, coverage missing | Local Lua and Python test doubles can drift from `26.1` registration, form, and source-handle behavior. | Extend repo tests and script-local harnesses before relying on the stubs for more compatibility work. | [#77](https://github.com/doppleganger53/sloppy-ethos/issues/77) |
+| `SensorList` | Partially aligned, runtime coverage incomplete | Existing defensive source discovery may still miss method-vs-field or table-vs-userdata drift on `26.1`, especially in simulator startup paths. | Validate on `X20RS`; recheck `X20S` whenever the reproduction overlaps the existing simulator bug surface. | [#82](https://github.com/doppleganger53/sloppy-ethos/issues/82), [#30](https://github.com/doppleganger53/sloppy-ethos/issues/30) |
+| `BoundryMap` | Highest active compatibility risk | GPS sub-value reads currently rely on `system.getSource({ ..., options = ... })`, boolean config fields assume `form.addBooleanField(...)`, and asset loading needs a `26.1` install/deploy check. | Validate packaged and deployed assets on `X20RS`, then confirm GPS/config behavior on hardware if simulator results are ambiguous. | [#78](https://github.com/doppleganger53/sloppy-ethos/issues/78), [#79](https://github.com/doppleganger53/sloppy-ethos/issues/79), [#80](https://github.com/doppleganger53/sloppy-ethos/issues/80) |
+| `ethos_events` | Best local runtime probe, `26.1` capture pending | The repo can already log raw events, but the current docs still point at an older upstream path and the `26.1` event map has not been recorded yet. | Deploy to both simulator targets and capture current raw touch/key constants before treating local event assumptions as settled. | [#81](https://github.com/doppleganger53/sloppy-ethos/issues/81) |
+| `SmartMapper` | Blocked on API proof | Reference examples confirm `model.createMix(...)` and `model.name()`, but do not yet prove the read/enumeration APIs needed to inspect existing mixes, switches, trims, or special functions. | Probe the reference checkout and runtime APIs before reviving implementation on the stale feature branch. | [#83](https://github.com/doppleganger53/sloppy-ethos/issues/83), [#45](https://github.com/doppleganger53/sloppy-ethos/issues/45) |
+| `Arduino FBus` | Feasibility unresolved | The surviving remote branch appears prompt-only, and the `26.1` reference scan did not expose a proven widget pattern for this work. | Decide whether to revive or retire the branch after reviewing the telemetry use case against current Ethos surfaces. | [#84](https://github.com/doppleganger53/sloppy-ethos/issues/84) |
+
+## Repo-Level Follow-Ups
+
+- [#85](https://github.com/doppleganger53/sloppy-ethos/issues/85):
+  reconcile stale branches before stacking more compatibility work onto old
+  refs.
+- [#86](https://github.com/doppleganger53/sloppy-ethos/issues/86):
+  governance drift around PR `#65` was closed during the baseline triage; keep
+  that closure linked because the compatibility backlog was created with that
+  dependency in mind.
+- [#87](https://github.com/doppleganger53/sloppy-ethos/issues/87):
+  update the contributor-facing script inventory and public compatibility status
+  without changing the published release-link policy.
+
+## Related Existing Issues
+
+- [#10](https://github.com/doppleganger53/sloppy-ethos/issues/10):
+  `SensorList` acceptable conflict definitions.
+- [#67](https://github.com/doppleganger53/sloppy-ethos/issues/67),
+  [#68](https://github.com/doppleganger53/sloppy-ethos/issues/68),
+  [#69](https://github.com/doppleganger53/sloppy-ethos/issues/69),
+  [#74](https://github.com/doppleganger53/sloppy-ethos/issues/74):
+  active `BoundryMap` feature work that should stay separate from the baseline
+  compatibility fixes above.

--- a/docs/ETHOS_26_1_COMPATIBILITY.md
+++ b/docs/ETHOS_26_1_COMPATIBILITY.md
@@ -10,8 +10,6 @@ across the repo.
 - Repository:
   `https://github.com/FrSkyRC/ETHOS-Feedback-Community.git`
 - Local path: `..\ETHOS-Feedback-Community`
-- Resolved Windows path:
-  `C:\Users\kurtk\Documents\Workspaces\EthosLua\ETHOS-Feedback-Community`
 - Branch: `26.1`
 - Commit: `e9d7afb7`
 - Baseline rule:

--- a/docs/REPOSITORY_LAYOUT.md
+++ b/docs/REPOSITORY_LAYOUT.md
@@ -47,6 +47,8 @@ This document explains the purpose of the top-level folders and key root files i
 
 - Contributor/developer-facing documentation.
 - Primary guide: `docs/DEVELOPMENT.md`.
+- Ethos `26.1` baseline:
+  [docs/ETHOS_26_1_COMPATIBILITY.md](ETHOS_26_1_COMPATIBILITY.md).
 - SensorList architecture reference: `docs/SensorList/SENSORLIST_ARCHITECTURE.md`.
 - This file (`docs/REPOSITORY_LAYOUT.md`) documents repository structure and root artifacts.
 

--- a/tests/test_docs_commands.py
+++ b/tests/test_docs_commands.py
@@ -12,6 +12,8 @@ from tests.helpers import REPO_ROOT, command_exists, run_command
 DOC_FILES = [
     REPO_ROOT / "README.md",
     REPO_ROOT / "docs" / "DEVELOPMENT.md",
+    REPO_ROOT / "docs" / "ETHOS_26_1_COMPATIBILITY.md",
+    REPO_ROOT / "docs" / "REPOSITORY_LAYOUT.md",
     *sorted((REPO_ROOT / "scripts").glob("*/README.md")),
     REPO_ROOT / "CONTRIBUTING.md",
     REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md",

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -13,6 +13,8 @@ from tests.test_docs_commands import DOC_FILES, discover_commands, is_manual_com
 
 README_PATH = REPO_ROOT / "README.md"
 DEVELOPMENT_PATH = REPO_ROOT / "docs" / "DEVELOPMENT.md"
+REPOSITORY_LAYOUT_PATH = REPO_ROOT / "docs" / "REPOSITORY_LAYOUT.md"
+COMPATIBILITY_BASELINE_PATH = REPO_ROOT / "docs" / "ETHOS_26_1_COMPATIBILITY.md"
 CONTRIBUTING_PATH = REPO_ROOT / "CONTRIBUTING.md"
 CODEOWNERS_PATH = REPO_ROOT / ".github" / "CODEOWNERS"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "SensorList" / "SENSORLIST_ARCHITECTURE.md"
@@ -159,6 +161,34 @@ def test_readme_has_visual_overview_section():
 def test_readme_links_sensorlist_architecture_doc():
     assert "(docs/SensorList/SENSORLIST_ARCHITECTURE.md)" in _read(README_PATH)
     assert ARCHITECTURE_PATH.exists()
+
+
+def test_core_docs_link_ethos_26_1_compatibility_baseline():
+    assert "(docs/ETHOS_26_1_COMPATIBILITY.md)" in _read(README_PATH)
+    assert "(ETHOS_26_1_COMPATIBILITY.md)" in _read(DEVELOPMENT_PATH)
+    assert "(ETHOS_26_1_COMPATIBILITY.md)" in _read(REPOSITORY_LAYOUT_PATH)
+    assert COMPATIBILITY_BASELINE_PATH.exists()
+
+
+def test_ethos_26_1_compatibility_baseline_captures_reference_targets_and_follow_ups():
+    text = _read(COMPATIBILITY_BASELINE_PATH)
+    for heading in ("## Reference Checkout", "## Validation Targets", "## Compatibility Matrix"):
+        assert heading in text
+    assert "ETHOS-Feedback-Community" in text
+    assert "`26.1`" in text
+    assert re.search(r"Commit:\s*`?[0-9a-f]{8}`?", text)
+    assert "git clone" in text
+    assert re.search(r"git\s+(-C\s+\S+\s+)?fetch\b", text)
+    assert "X20RS" in text
+    assert "X20S" in text
+    for area in ("SensorList", "BoundryMap", "ethos_events", "SmartMapper", "Arduino FBus"):
+        assert area in text
+
+
+def test_ethos_26_1_compatibility_baseline_links_follow_up_issues():
+    text = _read(COMPATIBILITY_BASELINE_PATH)
+    links = set(re.findall(r"https://github\.com/doppleganger53/sloppy-ethos/issues/(\d+)", text))
+    assert len(links) >= 5
 
 
 def test_contributing_has_workflow_section():


### PR DESCRIPTION
## Summary

Add a repo-level Ethos 26.1 compatibility baseline so future compatibility work has a single, reproducible reference checkout and validation target.

Closes #76

## Changes

- Added `docs/ETHOS_26_1_COMPATIBILITY.md` with the checked `ETHOS-Feedback-Community` `26.1` reference checkout, simulator targets, observed API patterns, compatibility matrix, and follow-up issue map.
- Linked the baseline doc from `README.md`, `docs/DEVELOPMENT.md`, and `docs/REPOSITORY_LAYOUT.md`.
- Extended docs tests to require the new baseline doc and verify the core reference facts and follow-up issue links.
- Updated `deslopification/memory/CURRENT_STATE.md` and added a session note so the new baseline is easy to rediscover.

## Verification

- [x] `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
- [x] `python tools/update_memory_catalog.py`

## Notes

- Linked issue(s): `#76`
- Expected merge strategy: `squash`
- Risks / follow-up items: downstream compatibility work continues in `#77` through `#84`.
