### PR TITLE
[codex] Add Ethos 26.1 API surface matrix

### DIFF
--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,17 +15,17 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-- Files: 121
-- Total size: 204,255 bytes
-- Total lines: 5,410
+- Files: 122
+- Total size: 205,815 bytes
+- Total lines: 5,459
 - Distribution by artifact:
-  - session notes: 115
+  - session notes: 116
   - handoff/restart notes: 3
   - reference notes: 2
   - summary notes: 1
 
 - Distribution by scope:
-  - 75 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
+  - 76 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
   - 17 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
   - 15 -- memory ( Memory system structure and retrieval policy )
   - 7 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
@@ -38,7 +38,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
   - 17 -- build
   - 15 -- release
   - 14 -- docs
-  - 7 -- testing
+  - 8 -- testing
   - 5 -- issue-admin
   - 5 -- prompts
   - 2 -- metadata
@@ -46,6 +46,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 ## Recent High-Signal Notes (Auto-generated)
 
 - Selection: newest session notes where `Concern` is one of `build`, `docs`, `metadata`, `release`, `testing`, or `workflow`; keep up to 3 per concern, then keep newest 12 overall.
+- 2026-05-06 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md](notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md) | # Session Notes 2026-05-06 - Issue #77 Ethos 26.1 API Surface Matrix
 - 2026-05-05 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md) | # Session Notes 2026-05-05 - Issue #76 Ethos 26.1 Baseline
 - 2026-04-27 | build | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md](notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md) | # Session Notes 2026-04-27 - PR71 Exclude Source Fix
 - 2026-04-27 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md](notes/session/repo/SESSION_NOTES_2026-04-27_ISSUE_72_SCRIPT_LOCAL_TESTS.md) | # Session Notes 2026-04-27 - Issue 72 Script Local Tests
@@ -57,7 +58,6 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md](notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md) | # Session Notes 2026-03-08 - VS Code Lua Coverage Workflow
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md](notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md) | # Session Notes 2026-03-08 - Debug Sessions Require Deploy
 - 2026-03-05 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md) | # Session Notes 2026-03-05 - Issue #56 Mutable Workflow Agent Metadata
-- 2026-03-05 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_54_LOW_SIGNAL_TEST_PRUNING.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_54_LOW_SIGNAL_TEST_PRUNING.md) | # Session Notes 2026-03-05 - Issue #54 Low-Signal Test Pruning
 
 ## Recent Ethos Platform Notes
 
@@ -194,3 +194,4 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-04-27 | session | repo | build | [notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md](notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md) | # Session Notes 2026-04-27 - PR71 Exclude Source Fix |
 | 2026-05-05 | session | repo | docs | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md) | # Session Notes 2026-05-05 - Issue #76 Ethos 26.1 Baseline |
 | 2026-05-05 | session | repo | implementation | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_86_AGENTIC_REORG_RETIREMENT.md) | # Session Notes 2026-05-05 - Issue 86 Agentic Reorg Retirement |
+| 2026-05-06 | session | repo | testing | [notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md](notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md) | # Session Notes 2026-05-06 - Issue #77 Ethos 26.1 API Surface Matrix |

--- a/deslopification/memory/CURRENT_STATE.md
+++ b/deslopification/memory/CURRENT_STATE.md
@@ -86,6 +86,10 @@ Historical detail remains in individual session notes referenced from
 - Ethos `26.1` compatibility baseline, reference checkout path, simulator
   targets, and follow-up issue map now live in
   `docs/ETHOS_26_1_COMPATIBILITY.md`.
+- The baseline doc now carries an API surface matrix for widget, tool, task,
+  form, source, and touch APIs, with BoundryMap's local harness aligned to the
+  checked `26.1` form surface by keeping `addBooleanField` optional and
+  modeling `addSourceField`.
 
 ## Active Tooling Decisions
 

--- a/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md
+++ b/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md
@@ -1,0 +1,49 @@
+# Session Notes 2026-05-06 - Issue #77 Ethos 26.1 API Surface Matrix
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `repo`
+- Concern: `testing`
+- Store this file under:
+  - `deslopification/memory/notes/{artifact}/{scope}/`
+
+## What changed
+
+- Expanded `docs/ETHOS_26_1_COMPATIBILITY.md` with an API surface matrix that
+  ties Ethos `26.1` widget, tool, task, source, form, and touch APIs to the
+  current repo scripts and smoke targets.
+- Aligned `scripts/BoundryMap/tests/lua/test_boundrymap.lua` with the checked
+  `26.1` form surface by adding `addSourceField` support and removing the
+  non-observed `addBooleanField` stub.
+- Extended docs contract coverage so the matrix and smoke targets stay
+  enforced.
+- Files touched:
+  - `docs/ETHOS_26_1_COMPATIBILITY.md`
+  - `scripts/BoundryMap/tests/lua/test_boundrymap.lua`
+  - `tests/test_docs_contracts.py`
+  - `deslopification/memory/CURRENT_STATE.md`
+
+## Why
+
+- Root cause or objective:
+  - Issue `#77` needed a concrete matrix tying Ethos `26.1` surfaces to repo
+    scripts and smoke targets so the local stubs stop drifting silently.
+- Scope guardrails:
+  - Kept runtime behavior changes out of scope; this change only updated docs,
+    tests, and local stubs.
+
+## Validation run(s)
+
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
+  - result: pass (`161 passed, 18 skipped`)
+- `python -m pytest scripts/SensorList/tests scripts/BoundryMap/tests -q`
+  - result: pass (`9 passed`)
+
+## Follow-up items
+
+- None.
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: yes

--- a/docs/ETHOS_26_1_COMPATIBILITY.md
+++ b/docs/ETHOS_26_1_COMPATIBILITY.md
@@ -50,25 +50,44 @@ confirm that it is still pinned to the tracked `26.1` branch.
 
 - Widget registration: `system.registerWidget(...)`
 - System tools and background tasks:
-  `system.registerSystemTool(...)`, `system.registerTask(...)`
+  `system.registerSystemTool(...)`, `system.registerTask(...)`,
+  `system.getMemoryUsage(...)`
 - Form fields seen in reference examples:
-  `form.addSensorField(...)`, `form.addChoiceField(...)`,
-  `form.addNumberField(...)`, `form.addTextButton(...)`,
+  `form.addSensorField(...)`, `form.addSourceField(...)`,
+  `form.addChoiceField(...)`, `form.addNumberField(...)`,
+  `form.addTextButton(...)`, `form.addBitmapField(...)`,
   `form.addStaticText(...)`
+  - `form.addBooleanField(...)` was not surfaced in the checked `26.1`
+    examples, so keep it optional in local code and stubs.
 - Bitmap loading patterns: `lcd.loadMask(...)`, `lcd.loadBitmap(...)`
 - Sensor/source access patterns:
   `system.getSource(...)`, then `source:value(...)` or
   `source:stringValue(...)`
+- Touch constants and categories:
+  `EVT_TOUCH*`, raw values `16640`, `16641`, `16642`
 - Model surfaces confirmed during triage:
   `model.createMix(...)`, `model.name()`
 
 ## Compatibility Matrix
 
+### API Surface Matrix
+
+| Surface | Used by | 26.1 evidence | Smoke target | Notes |
+| --- | --- | --- | --- | --- |
+| `system.registerWidget` / widget callbacks | SensorList: yes; BoundryMap: yes; ethos_events: no; SmartMapper: no; FBus: no | `lua/templates/widget/main.lua`, `lua/examples/widget-rssi/main.lua`, `lua/examples/widget-sinus/main.lua` | `python -m pytest scripts/SensorList/tests -q`, `python -m pytest scripts/BoundryMap/tests -q` | callback set includes `create`, `configure`, `paint`, `wakeup`, `event`, `read`, `write`, `menu`, `persistent` |
+| `system.registerSystemTool` / `lcd.loadMask` / `lcd.loadBitmap` | SensorList: no; BoundryMap: no; ethos_events: yes; SmartMapper: no; FBus: no | `lua/tests/emergency-test/main.lua`, `lua/tests/latency-test/main.lua`, `lua/examples/bluetooth/main.lua`, `lua/examples/widget-lcddemo/main.lua` | `python tools/build.py --project ethos_events --deploy` | `ethos_events` is the current local probe for system tool registration and touch-event logging |
+| `system.registerTask` / `system.getMemoryUsage` | SensorList: no; BoundryMap: no; ethos_events: no; SmartMapper: no; FBus: no | `lua/examples/task/main.lua`, `lua/examples/memstatus/main.lua` | reference-only until a task-based script lands | budget-sensitive helper APIs, no current local consumer |
+| `system.getSource` / `system.getSensors` / `model.getSensors` | SensorList: yes; BoundryMap: yes; ethos_events: no; SmartMapper: no; FBus: no | `lua/examples/widget-rssi/main.lua`, `lua/examples/widget-jet/main.lua`, `lua/examples/wizard/main.lua` | `python -m pytest scripts/SensorList/tests -q`, `python -m pytest scripts/BoundryMap/tests -q` | `SensorList` also exercises method-vs-field drift; `BoundryMap` uses source-handle reads for GPS and altitude |
+| `form.addSensorField` / `form.addSourceField` / `form.addChoiceField` / `form.addNumberField` / `form.addTextButton` / `form.addBitmapField` / `form.addStaticText` / `form.addBooleanField` | SensorList: yes; BoundryMap: yes; ethos_events: no; SmartMapper: no; FBus: no | `lua/examples/tool-form/main.lua`, `lua/examples/widget-jet/main.lua`, `lua/modules/crossfire/main.lua`, `lua/modules/elrs/main.lua` | `python -m pytest scripts/SensorList/tests -q`, `python -m pytest scripts/BoundryMap/tests -q` | `form.addBooleanField` was not surfaced in the checked `26.1` examples, so BoundryMap keeps that row optional and the local test harness omits the stub |
+| `EVT_TOUCH*` and raw touch values `16640`, `16641`, `16642` | SensorList: yes; BoundryMap: yes; ethos_events: yes; SmartMapper: no; FBus: no | `scripts/SensorList/main.lua`, `scripts/BoundryMap/main.lua`, `scripts/ethos_events/main.lua` | `python -m pytest scripts/SensorList/tests -q`, `python -m pytest scripts/BoundryMap/tests -q`, `python tools/build.py --project ethos_events --deploy` | local tests lock the raw-value mapping, while `ethos_events` remains the manual simulator probe |
+
+### Workstream Matrix
+
 | Area | Status | Current 26.1 risk | Validation target | Follow-up |
 | --- | --- | --- | --- | --- |
-| Shared Lua API stubs | Baseline defined, coverage missing | Local Lua and Python test doubles can drift from `26.1` registration, form, and source-handle behavior. | Extend repo tests and script-local harnesses before relying on the stubs for more compatibility work. | [#77](https://github.com/doppleganger53/sloppy-ethos/issues/77) |
+| Shared Lua API stubs | Compatibility matrix established; the local stubs now track the 26.1 source-field surface and keep boolean fields optional. | Local Lua and Python test doubles can still drift on unexercised task and memory-budget APIs. | Extend repo tests and script-local harnesses before relying on the stubs for more compatibility work. | [#78](https://github.com/doppleganger53/sloppy-ethos/issues/78), [#79](https://github.com/doppleganger53/sloppy-ethos/issues/79), [#80](https://github.com/doppleganger53/sloppy-ethos/issues/80) |
 | `SensorList` | Partially aligned, runtime coverage incomplete | Existing defensive source discovery may still miss method-vs-field or table-vs-userdata drift on `26.1`, especially in simulator startup paths. | Validate on `X20RS`; recheck `X20S` whenever the reproduction overlaps the existing simulator bug surface. | [#82](https://github.com/doppleganger53/sloppy-ethos/issues/82), [#30](https://github.com/doppleganger53/sloppy-ethos/issues/30) |
-| `BoundryMap` | Highest active compatibility risk | GPS sub-value reads currently rely on `system.getSource({ ..., options = ... })`, boolean config fields assume `form.addBooleanField(...)`, and asset loading needs a `26.1` install/deploy check. | Validate packaged and deployed assets on `X20RS`, then confirm GPS/config behavior on hardware if simulator results are ambiguous. | [#78](https://github.com/doppleganger53/sloppy-ethos/issues/78), [#79](https://github.com/doppleganger53/sloppy-ethos/issues/79), [#80](https://github.com/doppleganger53/sloppy-ethos/issues/80) |
+| `BoundryMap` | Highest active compatibility risk | GPS sub-value reads currently rely on `system.getSource({ ..., options = ... })`, and the `26.1` surface keeps boolean config fields optional rather than guaranteed. | Validate packaged and deployed assets on `X20RS`, then confirm GPS/config behavior on hardware if simulator results are ambiguous. | [#78](https://github.com/doppleganger53/sloppy-ethos/issues/78), [#79](https://github.com/doppleganger53/sloppy-ethos/issues/79), [#80](https://github.com/doppleganger53/sloppy-ethos/issues/80) |
 | `ethos_events` | Best local runtime probe, `26.1` capture pending | The repo can already log raw events, but the current docs still point at an older upstream path and the `26.1` event map has not been recorded yet. | Deploy to both simulator targets and capture current raw touch/key constants before treating local event assumptions as settled. | [#81](https://github.com/doppleganger53/sloppy-ethos/issues/81) |
 | `SmartMapper` | Blocked on API proof | Reference examples confirm `model.createMix(...)` and `model.name()`, but do not yet prove the read/enumeration APIs needed to inspect existing mixes, switches, trims, or special functions. | Probe the reference checkout and runtime APIs before reviving implementation on the stale feature branch. | [#83](https://github.com/doppleganger53/sloppy-ethos/issues/83), [#45](https://github.com/doppleganger53/sloppy-ethos/issues/45) |
 | `Arduino FBus` | Feasibility unresolved | The surviving remote branch appears prompt-only, and the `26.1` reference scan did not expose a proven widget pattern for this work. | Decide whether to revive or retire the branch after reviewing the telemetry use case against current Ethos surfaces. | [#84](https://github.com/doppleganger53/sloppy-ethos/issues/84) |

--- a/scripts/BoundryMap/tests/lua/test_boundrymap.lua
+++ b/scripts/BoundryMap/tests/lua/test_boundrymap.lua
@@ -42,7 +42,12 @@ end
 
 _G.system = {
   registerWidget = function(_) end,
+  registerSystemTool = function(_) end,
+  registerTask = function(_) end,
   getSource = function(_) return nil end,
+  getMemoryUsage = function()
+    return 0
+  end,
   playHaptic = function(_) return true end,
   playTone = function(...) return true end,
 }
@@ -74,6 +79,12 @@ _G.form = {
     formRows[row].getter = getter
     formRows[row].setter = setter
   end,
+  -- Ethos 26.1 examples surface source fields, but not boolean fields.
+  addSourceField = function(row, _, getter, setter)
+    formRows[row].type = "source"
+    formRows[row].getter = getter
+    formRows[row].setter = setter
+  end,
   addChoiceField = function(row, _, choices, getter, setter)
     formRows[row].type = "choice"
     formRows[row].choices = choices
@@ -84,11 +95,6 @@ _G.form = {
     formRows[row].type = "number"
     formRows[row].low = low
     formRows[row].high = high
-    formRows[row].getter = getter
-    formRows[row].setter = setter
-  end,
-  addBooleanField = function(row, _, getter, setter)
-    formRows[row].type = "boolean"
     formRows[row].getter = getter
     formRows[row].setter = setter
   end,
@@ -121,6 +127,17 @@ _G.lcd = {
   drawFilledCircle = function(_, _, _) end,
   drawBitmap = function(x, y, bitmap)
     drawnBitmaps[#drawnBitmaps + 1] = { x = x, y = y, name = bitmap and bitmap.name or "" }
+  end,
+  loadMask = function(path)
+    return {
+      name = path,
+      width = function()
+        return 16
+      end,
+      height = function()
+        return 20
+      end,
+    }
   end,
   loadBitmap = function(path)
     if path and path:find("icons/", 1, true) then

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -104,6 +104,10 @@ def test_documented_local_file_references_exist(ref: str):
     if path.exists():
         return
 
+    # Ethos compatibility docs cite upstream reference-checkout examples under lua/.
+    if ref.startswith("lua/") or ref.startswith("lua\\"):
+        return
+
     # Allow local-only config files when docs also point to a committed template.
     if ref.endswith(".json") and _has_companion_example(ref):
         return
@@ -172,7 +176,7 @@ def test_core_docs_link_ethos_26_1_compatibility_baseline():
 
 def test_ethos_26_1_compatibility_baseline_captures_reference_targets_and_follow_ups():
     text = _read(COMPATIBILITY_BASELINE_PATH)
-    for heading in ("## Reference Checkout", "## Validation Targets", "## Compatibility Matrix"):
+    for heading in ("## Reference Checkout", "## Validation Targets", "## Compatibility Matrix", "### API Surface Matrix"):
         assert heading in text
     assert "ETHOS-Feedback-Community" in text
     assert "`26.1`" in text
@@ -183,6 +187,43 @@ def test_ethos_26_1_compatibility_baseline_captures_reference_targets_and_follow
     assert "X20S" in text
     for area in ("SensorList", "BoundryMap", "ethos_events", "SmartMapper", "Arduino FBus"):
         assert area in text
+
+
+def test_ethos_26_1_api_surface_matrix_lists_shared_surfaces_and_smoke_targets():
+    text = _read(COMPATIBILITY_BASELINE_PATH)
+    for token in (
+        "system.registerWidget",
+        "system.registerSystemTool",
+        "system.registerTask",
+        "system.getMemoryUsage",
+        "system.getSource",
+        "system.getSensors",
+        "model.getSensors",
+        "form.addSensorField",
+        "form.addSourceField",
+        "form.addChoiceField",
+        "form.addNumberField",
+        "form.addTextButton",
+        "form.addBitmapField",
+        "form.addStaticText",
+        "form.addBooleanField",
+        "EVT_TOUCH",
+        "16640",
+        "16641",
+        "16642",
+    ):
+        assert token in text
+    for token in (
+        "SensorList: yes",
+        "BoundryMap: yes",
+        "ethos_events: yes",
+        "SmartMapper: no",
+        "FBus: no",
+        "python -m pytest scripts/SensorList/tests -q",
+        "python -m pytest scripts/BoundryMap/tests -q",
+        "python tools/build.py --project ethos_events --deploy",
+    ):
+        assert token in text
 
 
 def test_ethos_26_1_compatibility_baseline_links_follow_up_issues():


### PR DESCRIPTION
## What changed
- Expanded `docs/ETHOS_26_1_COMPATIBILITY.md` with an API surface matrix covering widget, tool, task, source, form, and touch APIs.
- Aligned the BoundryMap test harness with the checked Ethos `26.1` form surface by modeling `addSourceField` and leaving `addBooleanField` optional.
- Tightened docs-contract coverage and synced repo memory.

## Why
Issue #77 needed a concrete matrix tying the `26.1` reference checkout to local scripts and smoke targets so stub drift is visible before it causes compatibility regressions.

## Validation
- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py -q`
- `python -m pytest scripts/SensorList/tests scripts/BoundryMap/tests -q`
- `python -m pytest tests/test_memory_catalog_sync.py -q`

Closes #77
