### PR TITLE
Document EthosLua workspace agent transition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,28 @@ Repository-level operating policy for Codex sessions in `sloppy-ethos`.
 
 ## Priority And Scope
 
-- These rules are repository-wide and apply to every task in this workspace.
+- These rules are repository-wide and apply to every task in this checkout.
+- If a session starts from the parent `EthosLua` workspace, first read the
+  workspace `AGENTS.MD`, then enter `sloppy-ethos/` before applying this
+  repository policy.
 - Keep changes scoped to the user request. Do not perform unrelated cleanup or broad refactors.
 - Preserve existing behavior unless the task explicitly requests behavior changes.
+
+## Parent Workspace And Reference Checkouts
+
+- The parent `EthosLua` workspace is an orchestration shell; this repository is
+  the primary implementation repo.
+- Sibling directories such as `ETHOS-Feedback-Community/`,
+  `ETHOS-Feedback-Community-prerelease/`, and `Ethos-GPS-AccuMapv1/` are
+  reference checkouts, not part of this repo's working tree.
+- Treat sibling reference projects as read-only evidence unless the user
+  explicitly asks to update or modify them.
+- Pull reference updates only with commands scoped to that checkout, for
+  example `git -C ../ETHOS-Feedback-Community pull --ff-only`.
+- Do not stage parent-workspace or sibling-reference files into `sloppy-ethos`.
+- Before copying code, docs, or assets from a reference project, verify the
+  source license and record attribution in the relevant repo docs or session
+  notes.
 
 ## Root-Cause Strategy
 
@@ -29,20 +48,22 @@ Repository-level operating policy for Codex sessions in `sloppy-ethos`.
 
 ## Required Startup Workflow
 
-1. Read memory entrypoint files:
+1. If launched from the parent `EthosLua` workspace, `cd sloppy-ethos` before
+   running repository commands.
+2. Read memory entrypoint files:
    - `deslopification/memory/README.md`
    - `deslopification/memory/CURRENT_STATE.md`
-2. Use `deslopification/memory/CATALOG.md` to open only the latest relevant
+3. Use `deslopification/memory/CATALOG.md` to open only the latest relevant
    note(s) for the current task.
-3. Determine session type:
+4. Determine session type:
    - issue-linked work (GitHub issue URL/number present, or session driven by
      `deslopification/prompts/issues/*.md`)
    - non-issue work
-4. For issue-linked work, run preflight before editing:
+5. For issue-linked work, run preflight before editing:
    - `python tools/session_preflight.py --mode issue --issue-number {N} --issue-kind {enhancement|bug|docs|chore} --slug {short-slug}`
-5. Check branch/worktree state: `git status --short --branch`.
-6. Confirm active package version from `VERSION`.
-7. Before introducing or changing workflow commands, cross-check command docs in:
+6. Check branch/worktree state: `git status --short --branch`.
+7. Confirm active package version from `VERSION`.
+8. Before introducing or changing workflow commands, cross-check command docs in:
    - `README.md`
    - `docs/DEVELOPMENT.md`
 
@@ -159,5 +180,7 @@ Repository-level operating policy for Codex sessions in `sloppy-ethos`.
 
 - Required validation commands for touched files completed in this session.
 - If the session was a simulator debugging session for a Lua script, the updated script was deployed to the simulator in this session.
-- Workspace and `.gitignore` reviewed for environment-specific files and sensitive data risks.
+- Parent workspace, repository status, and `.gitignore` reviewed for
+  environment-specific files, sibling-reference changes, and sensitive data
+  risks.
 - Any potential security concern (PII, PHI, secrets, unsafe config, API keys, auth tokens) explicitly called out to the user.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,17 +12,21 @@
 
 ## Workflow
 
-1. Create a short-lived branch from the latest `main` using naming conventions:
+1. If you start from the parent `EthosLua` workspace, enter `sloppy-ethos/`
+   before running repository commands. The parent `AGENTS.MD` defines workspace
+   boundaries; this repo's `AGENTS.md` defines the contribution and agent
+   workflow once inside the checkout.
+2. Create a short-lived branch from the latest `main` using naming conventions:
    - `feature/{issue-number}-{short-slug}` for enhancements
    - `fix/{issue-number}-{short-slug}` for bugs
    - `docs/{issue-number}-{short-slug}` for docs/process changes
    - `chore/{issue-number}-{short-slug}` for maintenance/tooling changes
-2. Keep changes focused and scoped to one concern.
-3. If installable script behavior/assets changed, bump that script `scripts/{ProjectName}/VERSION` in the same PR. Do not bump version files for docs-only or workflow-only changes.
+3. Keep changes focused and scoped to one concern.
+4. If installable script behavior/assets changed, bump that script `scripts/{ProjectName}/VERSION` in the same PR. Do not bump version files for docs-only or workflow-only changes.
    If the script needs installable files outside `/scripts` or optional local assets under its own script folder, declare them in a project-local build manifest so `tools/build.py` can package, deploy, and clean them consistently.
    Keep user-specific location assets local. For BoundryMap, place private flying-site maps under the ignored `scripts/BoundryMap/assets/maps/` folder and let the generic `assets` manifest entries package them.
-4. Do not bump root `VERSION` on issue branches; root release versioning is finalized on `release/v{VERSION}`.
-5. Run local checks before opening a PR:
+5. Do not bump root `VERSION` on issue branches; root release versioning is finalized on `release/v{VERSION}`.
+6. Run local checks before opening a PR:
    - `luac -p scripts/SensorList/main.lua`
    - package build:
      `python tools/build.py --project SensorList --dist`
@@ -35,13 +39,24 @@
    - one script's local tests when touching that script's behavior:
      `python -m pytest scripts/{ProjectName}/tests -q`
    - `stylua --config-path tools/config/stylua.toml scripts` (if formatting changed)
-6. Open a PR into `main` using the repository PR template and include linked-closing issue keywords (for example, `Closes #29`).
-7. Use the repository merge strategy policy:
+7. Open a PR into `main` using the repository PR template and include linked-closing issue keywords (for example, `Closes #29`).
+8. Use the repository merge strategy policy:
    - `squash` merge for normal issue PRs (`feature/`, `fix/`, `docs/`, `chore/`).
    - `merge commit` for release-prep PRs (`release/v{VERSION}`) or lineage-sensitive PRs.
    - avoid `rebase` merge as default.
-8. Do not manually close linked issues before merge; let GitHub close them from the merged PR closing keywords.
-9. Follow release branch/tag flow in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#main-branch-release-and-versioning-policy) and [Release Workflow](docs/DEVELOPMENT.md#release-workflow).
+9. Do not manually close linked issues before merge; let GitHub close them from the merged PR closing keywords.
+10. Follow release branch/tag flow in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#main-branch-release-and-versioning-policy) and [Release Workflow](docs/DEVELOPMENT.md#release-workflow).
+
+## Reference Checkouts
+
+- Sibling directories in the parent `EthosLua` workspace are references, not
+  part of this repo.
+- Update reference repos only with commands scoped to that checkout, for
+  example `git -C ../ETHOS-Feedback-Community pull --ff-only`.
+- Treat reference projects as read-only evidence unless an issue or user request
+  explicitly calls for updating them.
+- Verify license and attribution before copying reference code, docs, or assets
+  into `sloppy-ethos`.
 
 ## Documentation Changes
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ To build a single install ZIP with multiple scripts:
 
 - Recommended development environment: [Visual Studio Code](https://code.visualstudio.com/).
 - Recommended coding agent: [OpenAI Codex](https://openai.com/codex/).
+- If your Codex session starts in the parent `EthosLua` workspace, treat
+  `sloppy-ethos/` as the implementation repo and enter it before running repo
+  commands. The parent `AGENTS.MD` only defines workspace boundaries; this
+  repository's `AGENTS.md` remains the source of truth once inside the repo.
+- Keep sibling reference checkouts such as `ETHOS-Feedback-Community/` and
+  `Ethos-GPS-AccuMapv1/` separate from this repo. Pull them with scoped
+  commands such as `git -C ../ETHOS-Feedback-Community pull --ff-only`, and
+  treat them as read-only evidence unless you are explicitly updating them.
+- Before copying reference code, docs, or assets into this repo, verify the
+  upstream license and record attribution.
 - Format Lua: VS Code task `Format Lua (stylua)` or run `stylua --config-path tools/config/stylua.toml scripts`
 - Build package: VS Code task `Build Ethos Install ZIP`
 - Lua parse check:
@@ -157,6 +167,8 @@ luac -p scripts/SensorList/main.lua
 - Start session-memory context with `deslopification/memory/README.md`.
 - Use `deslopification/memory/CATALOG.md` for full historical note lookup.
 - Workflow/process guidance is intentionally mutable; issue-linked workflow updates must keep `AGENTS.md`, `CONTRIBUTING.md`, and `docs/DEVELOPMENT.md` synchronized.
+- Parent-workspace policy changes live outside this repo; repo behavior,
+  validation, release, and memory work still happens inside `sloppy-ethos/`.
 
 ## Troubleshooting
 

--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,17 +15,17 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-- Files: 125
-- Total size: 212,467 bytes
-- Total lines: 5,630
+- Files: 126
+- Total size: 214,246 bytes
+- Total lines: 5,683
 - Distribution by artifact:
-  - session notes: 119
+  - session notes: 120
   - handoff/restart notes: 3
   - reference notes: 2
   - summary notes: 1
 
 - Distribution by scope:
-  - 78 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
+  - 79 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
   - 17 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
   - 15 -- memory ( Memory system structure and retrieval policy )
   - 8 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
@@ -34,7 +34,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 
 - Distribution by concern:
   - 32 -- implementation
-  - 26 -- workflow
+  - 27 -- workflow
   - 17 -- build
   - 15 -- release
   - 14 -- docs
@@ -46,6 +46,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 ## Recent High-Signal Notes (Auto-generated)
 
 - Selection: newest session notes where `Concern` is one of `build`, `docs`, `metadata`, `release`, `testing`, or `workflow`; keep up to 3 per concern, then keep newest 12 overall.
+- 2026-05-30 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md](notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md) | # Session Notes 2026-05-30 - Issue #95 workspace AGENTS transition
 - 2026-05-06 | testing | repo | [notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md](notes/session/repo/SESSION_NOTES_2026-05-06_ISSUE_77_ETHOS_26_1_API_SURFACE_MATRIX.md) | # Session Notes 2026-05-06 - Issue #77 Ethos 26.1 API Surface Matrix
 - 2026-05-05 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md) | # Session Notes 2026-05-05 - Issue #76 Ethos 26.1 Baseline
 - 2026-04-27 | build | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md](notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md) | # Session Notes 2026-04-27 - PR71 Exclude Source Fix
@@ -57,7 +58,6 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 - 2026-03-09 | release | sensorlist | [notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md](notes/session/sensorlist/SESSION_NOTES_2026-03-09_SENSORLIST_V101_RELEASE.md) | # Session Notes 2026-03-09 - SensorList-v1.0.1 Release
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md](notes/session/repo/SESSION_NOTES_2026-03-08_VSCODE_LUA_COVERAGE_WORKFLOW.md) | # Session Notes 2026-03-08 - VS Code Lua Coverage Workflow
 - 2026-03-08 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md](notes/session/repo/SESSION_NOTES_2026-03-08_DEBUG_SESSIONS_REQUIRE_DEPLOY.md) | # Session Notes 2026-03-08 - Debug Sessions Require Deploy
-- 2026-03-05 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md](notes/session/repo/SESSION_NOTES_2026-03-05_ISSUE_56_MUTABLE_WORKFLOW_AGENT_METADATA.md) | # Session Notes 2026-03-05 - Issue #56 Mutable Workflow Agent Metadata
 
 ## Recent Ethos Platform Notes
 
@@ -198,3 +198,4 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-05-09 | session | ethos-platform | implementation | [notes/session/ethos-platform/SESSION_NOTES_2026-05-09_ETHOS_26_1_RELEASE_DOCS_GETSOURCES.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-09_ETHOS_26_1_RELEASE_DOCS_GETSOURCES.md) | # Session Notes 2026-05-09 - Ethos 26.1 Release Docs And getSources |
 | 2026-05-09 | session | repo | issue-admin | [notes/session/repo/SESSION_NOTES_2026-05-09_ISSUE_85_BRANCH_RECONCILIATION.md](notes/session/repo/SESSION_NOTES_2026-05-09_ISSUE_85_BRANCH_RECONCILIATION.md) | # Session Notes 2026-05-09 - Issue 85 branch reconciliation |
 | 2026-05-09 | session | repo | implementation | [notes/session/repo/SESSION_NOTES_2026-05-09_SMARTMAPPER_API_PROBE.md](notes/session/repo/SESSION_NOTES_2026-05-09_SMARTMAPPER_API_PROBE.md) | # Session Notes 2026-05-09 - SmartMapper API Probe |
+| 2026-05-30 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md](notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md) | # Session Notes 2026-05-30 - Issue #95 workspace AGENTS transition |

--- a/deslopification/memory/CURRENT_STATE.md
+++ b/deslopification/memory/CURRENT_STATE.md
@@ -1,4 +1,4 @@
-# Current State (2026-05-05)
+# Current State (2026-05-30)
 
 This file is the high-signal memory entrypoint for cold-start sessions.
 Historical detail remains in individual session notes referenced from
@@ -20,6 +20,16 @@ Historical detail remains in individual session notes referenced from
 - Workflow/process guidance is intentionally mutable; issue-linked policy
   changes must keep `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, and
   `docs/DEVELOPMENT.md` synchronized in the same session.
+- `sloppy-ethos` can be operated from the parent `EthosLua` workspace, but
+  repository work must enter the `sloppy-ethos/` checkout before applying repo
+  policy, running preflight, editing files, validating, or updating memory.
+- The parent workspace `AGENTS.MD` defines workspace boundaries; this repo's
+  `AGENTS.md` remains authoritative for repo behavior after entering the
+  checkout.
+- Sibling Ethos checkouts in the parent workspace are reference evidence unless
+  explicitly requested otherwise. Pull them only with checkout-scoped commands
+  such as `git -C ../ETHOS-Feedback-Community pull --ff-only`, and verify
+  license/attribution before copying reference material into this repo.
 - Validation is mandatory for all changes per `AGENTS.md` matrix.
 - Documentation/process changes require docs contract validation.
 - Session memory updates are required for meaningful workflow/behavior changes.

--- a/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md
+++ b/deslopification/memory/notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md
@@ -1,0 +1,53 @@
+# Session Notes 2026-05-30 - Issue #95 workspace AGENTS transition
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `repo`
+- Concern: `workflow`
+- Store this file under:
+  - `deslopification/memory/notes/session/repo/`
+
+## What changed
+
+- Documented the parent `EthosLua` workspace boundary for agents and
+  contributors.
+- Clarified that `sloppy-ethos/AGENTS.md` remains authoritative once a session
+  enters this repository.
+- Added guardrails for sibling reference checkouts:
+  - treat them as read-only evidence by default
+  - update them only with checkout-scoped Git commands
+  - verify license and attribution before copying reference material
+- Files touched:
+  - `AGENTS.md`
+  - `README.md`
+  - `CONTRIBUTING.md`
+  - `docs/DEVELOPMENT.md`
+  - `deslopification/prompts/templates/ISSUE_RESOLUTION_TEMPLATE.md`
+  - `deslopification/memory/CURRENT_STATE.md`
+  - `deslopification/memory/CATALOG.md`
+
+## Why
+
+- Root cause or objective:
+  - Agents may now start from the parent `EthosLua` workspace, while
+    implementation and repo workflow must remain scoped to `sloppy-ethos/`.
+- Scope guardrails:
+  - No runtime API, Lua behavior, build behavior, or release versioning changed.
+  - Reference projects were not modified.
+
+## Validation run(s)
+
+- `python tools/update_memory_catalog.py`
+  - result: pass; regenerated `deslopification/memory/CATALOG.md`
+- `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py tests/test_memory_catalog_sync.py tests/test_prompt_guardrails.py -q`
+  - result: pass; 205 passed, 21 skipped
+
+## Follow-up items
+
+- Convert or replace the parent workspace's local `GPSAccuMap2.0/` snapshot with
+  a pullable Git checkout only after its upstream remote is confirmed.
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: yes

--- a/deslopification/prompts/templates/ISSUE_RESOLUTION_TEMPLATE.md
+++ b/deslopification/prompts/templates/ISSUE_RESOLUTION_TEMPLATE.md
@@ -23,6 +23,8 @@ the stated acceptance criteria and repository policies.
 
 You are Codex working directly in this repository.
 
+- If launched from the parent `EthosLua` workspace, first read the parent
+  `AGENTS.MD`, then enter `sloppy-ethos/` before applying this template.
 - Keep changes focused on this issue only.
 - Preserve existing behavior unless this issue explicitly changes behavior.
 - Prefer minimal, high-signal diffs over broad refactors.
@@ -30,16 +32,18 @@ You are Codex working directly in this repository.
 
 ## Mandatory Startup Workflow
 
-1. Read memory entrypoint files:
+1. Confirm the working directory is the `sloppy-ethos` repository, not the
+   parent `EthosLua` workspace or a sibling reference checkout.
+2. Read memory entrypoint files:
    - `deslopification/memory/README.md`
    - `deslopification/memory/CURRENT_STATE.md`
-2. Use `deslopification/memory/CATALOG.md` to load only task-relevant note(s).
-3. Run `git status --short --branch`.
-4. Confirm root version from `VERSION`.
-5. Cross-check workflow commands in:
+3. Use `deslopification/memory/CATALOG.md` to load only task-relevant note(s).
+4. Run `git status --short --branch`.
+5. Confirm root version from `VERSION`.
+6. Cross-check workflow commands in:
    - `README.md`
    - `docs/DEVELOPMENT.md`
-6. Review issue body/comments and linked artifacts.
+7. Review issue body/comments and linked artifacts.
 
 ## Branch And Worktree Gate (Required Before Editing)
 
@@ -111,6 +115,9 @@ Document the runtime interaction contract before editing:
 - No destructive git commands.
 - No unrelated cleanup.
 - Keep temporary analysis artifacts in `deslopification/memory/temp/`.
+- Treat sibling reference checkouts as read-only evidence unless the issue or
+  user request explicitly asks to update them. Before copying reference code,
+  docs, or assets, verify license and attribution requirements.
 
 ## Validation Matrix (Required)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,6 +15,19 @@
 - Lua tooling on PATH (`lua`, `luac`)
 - Optional: `stylua` for formatting
 
+## Parent Workspace Boundary
+
+- `sloppy-ethos/` is the primary implementation repository inside the parent
+  `EthosLua` workspace.
+- If a session starts from the parent workspace, read the parent `AGENTS.MD`,
+  then enter `sloppy-ethos/` before running repository commands or applying
+  this repo's policy.
+- Keep sibling reference checkouts outside this repo's Git scope. Use scoped
+  update commands such as `git -C ../ETHOS-Feedback-Community pull --ff-only`.
+- Treat references as read-only evidence unless a user request explicitly asks
+  to update them, and verify license/attribution before copying anything into
+  this repository.
+
 ## Core Commands
 
 - Syntax check:


### PR DESCRIPTION
## Summary

- document the parent EthosLua workspace boundary for Codex and contributors
- clarify that sloppy-ethos remains the primary implementation repo once a session enters the checkout
- add reference-checkout guardrails for scoped pulls, read-only evidence use, and license/attribution review
- record the durable workflow change in repository memory and refresh the catalog

Closes #95

## Verification

- [x] Documentation changes: `python -m pytest tests/test_docs_commands.py tests/test_docs_contracts.py tests/test_memory_catalog_sync.py tests/test_prompt_guardrails.py -q`
- [x] Memory catalog sync: `python tools/update_memory_catalog.py --check`

## Notes

- Parent workspace `AGENTS.MD` was committed locally in the outer `EthosLua` workspace as `41eef94`; that workspace has no Git remote configured, so it is not part of this PR.
- Existing untracked `tools/sim/` content in this checkout was left untouched.
