### PR TITLE
Cover unsafe WebSimulator ZIP paths

### DIFF
--- a/deslopification/memory/CATALOG.md
+++ b/deslopification/memory/CATALOG.md
@@ -15,11 +15,11 @@ Pre-optimization baseline (before Issue #16 on 2026-02-26):
 
 Current snapshot (auto-generated, excludes `CATALOG.md`):
 
-- Files: 134
-- Total size: 232,086 bytes
-- Total lines: 6,141
+- Files: 135
+- Total size: 233,089 bytes
+- Total lines: 6,178
 - Distribution by artifact:
-  - session notes: 128
+  - session notes: 129
   - handoff/restart notes: 3
   - reference notes: 2
   - summary notes: 1
@@ -27,7 +27,7 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 - Distribution by scope:
   - 80 -- repo ( Repository workflow, release, docs, testing, prompts, and metadata )
   - 17 -- sensorlist ( SensorList-specific behavior, release history, and operating notes )
-  - 15 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
+  - 16 -- ethos-platform ( Reusable Ethos runtime, API, simulator, and environment knowledge )
   - 15 -- memory ( Memory system structure and retrieval policy )
   - 4 -- ethos-events ( ethos_events-specific behavior, release history, and operating notes )
   - 3 -- handoff ( Session continuity and restart handoffs )
@@ -36,8 +36,8 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
   - 32 -- implementation
   - 28 -- workflow
   - 17 -- build
+  - 16 -- testing
   - 15 -- release
-  - 15 -- testing
   - 14 -- docs
   - 6 -- issue-admin
   - 5 -- prompts
@@ -46,11 +46,11 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 ## Recent High-Signal Notes (Auto-generated)
 
 - Selection: newest session notes where `Concern` is one of `build`, `docs`, `metadata`, `release`, `testing`, or `workflow`; keep up to 3 per concern, then keep newest 12 overall.
+- 2026-05-30 | testing | ethos-platform | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md) | # Session Notes 2026-05-30 - WebSimulator ZIP Traversal Test
 - 2026-05-30 | testing | ethos-platform | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_TIMEOUT_LOGS.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_TIMEOUT_LOGS.md) | # Session Notes 2026-05-30 - WebSimulator Timeout Logs
 - 2026-05-30 | testing | ethos-platform | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_LATEST_ALIAS_CACHE.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_LATEST_ALIAS_CACHE.md) | # Session Notes 2026-05-30 - WebSimulator Latest Alias Cache
 - 2026-05-30 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-05-30_PR94_CONFLICT_RESOLUTION.md](notes/session/repo/SESSION_NOTES_2026-05-30_PR94_CONFLICT_RESOLUTION.md) | # Session Notes 2026-05-30 - PR #94 conflict resolution
 - 2026-05-30 | workflow | repo | [notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md](notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md) | # Session Notes 2026-05-30 - Issue #95 workspace AGENTS transition
-- 2026-05-18 | testing | ethos-platform | [notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_SHARED_PERSIST.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_SHARED_PERSIST.md) | # Session Notes 2026-05-18 - WebSimulator Shared Persist
 - 2026-05-05 | docs | repo | [notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md](notes/session/repo/SESSION_NOTES_2026-05-05_ISSUE_76_ETHOS_26_1_BASELINE.md) | # Session Notes 2026-05-05 - Issue #76 Ethos 26.1 Baseline
 - 2026-04-27 | build | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md](notes/session/repo/SESSION_NOTES_2026-04-27_PR71_EXCLUDE_SOURCE_FIX.md) | # Session Notes 2026-04-27 - PR71 Exclude Source Fix
 - 2026-04-27 | build | repo | [notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md](notes/session/repo/SESSION_NOTES_2026-04-27_GENERIC_BUILD_ASSETS.md) | # Session Notes 2026-04-27 - Generic Build Assets
@@ -62,12 +62,12 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 ## Recent Ethos Platform Notes
 
 - Selection: newest `session` and `reference` notes where `Scope` is `ethos-platform`; keep newest 6 overall.
+- 2026-05-30 | session | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md) | # Session Notes 2026-05-30 - WebSimulator ZIP Traversal Test
 - 2026-05-30 | session | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_TIMEOUT_LOGS.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_TIMEOUT_LOGS.md) | # Session Notes 2026-05-30 - WebSimulator Timeout Logs
 - 2026-05-30 | session | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_LATEST_ALIAS_CACHE.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_LATEST_ALIAS_CACHE.md) | # Session Notes 2026-05-30 - WebSimulator Latest Alias Cache
 - 2026-05-18 | session | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_SHARED_PERSIST.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_SHARED_PERSIST.md) | # Session Notes 2026-05-18 - WebSimulator Shared Persist
 - 2026-05-18 | session | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_RUNTIME_CACHE_REUSE.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_RUNTIME_CACHE_REUSE.md) | # Session Notes 2026-05-18 - WebSimulator Runtime Cache Reuse
 - 2026-05-18 | session | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_GUI_RGB565_FIX.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_GUI_RGB565_FIX.md) | # Session Notes 2026-05-18 - WebSimulator GUI RGB565 Fix
-- 2026-05-18 | session | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_CACHE_RESILIENCE.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_CACHE_RESILIENCE.md) | # Session Notes 2026-05-18 - WebSimulator Cache Resilience
 
 ## Entries
 
@@ -205,5 +205,6 @@ Current snapshot (auto-generated, excludes `CATALOG.md`):
 | 2026-05-18 | session | ethos-platform | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_SHARED_PERSIST.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-18_WEBSIM_SHARED_PERSIST.md) | # Session Notes 2026-05-18 - WebSimulator Shared Persist |
 | 2026-05-30 | session | ethos-platform | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_LATEST_ALIAS_CACHE.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_LATEST_ALIAS_CACHE.md) | # Session Notes 2026-05-30 - WebSimulator Latest Alias Cache |
 | 2026-05-30 | session | ethos-platform | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_TIMEOUT_LOGS.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_TIMEOUT_LOGS.md) | # Session Notes 2026-05-30 - WebSimulator Timeout Logs |
+| 2026-05-30 | session | ethos-platform | testing | [notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md](notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md) | # Session Notes 2026-05-30 - WebSimulator ZIP Traversal Test |
 | 2026-05-30 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md](notes/session/repo/SESSION_NOTES_2026-05-30_ISSUE_95_WORKSPACE_AGENTS_TRANSITION.md) | # Session Notes 2026-05-30 - Issue #95 workspace AGENTS transition |
 | 2026-05-30 | session | repo | workflow | [notes/session/repo/SESSION_NOTES_2026-05-30_PR94_CONFLICT_RESOLUTION.md](notes/session/repo/SESSION_NOTES_2026-05-30_PR94_CONFLICT_RESOLUTION.md) | # Session Notes 2026-05-30 - PR #94 conflict resolution |

--- a/deslopification/memory/notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md
+++ b/deslopification/memory/notes/session/ethos-platform/SESSION_NOTES_2026-05-30_WEBSIM_ZIP_TRAVERSAL_TEST.md
@@ -1,0 +1,37 @@
+# Session Notes 2026-05-30 - WebSimulator ZIP Traversal Test
+
+## Note Placement
+
+- Artifact: `session`
+- Scope: `ethos-platform`
+- Concern: `testing`
+- Store this file under:
+  - `deslopification/memory/notes/session/ethos-platform/`
+
+## What changed
+
+- Added regression coverage in `tests/test_sim_harness.py` for unsafe
+  WebSimulator archive members in `safe_extract_zip()`.
+- The test covers parent-directory traversal and absolute-path member names,
+  asserting the extractor raises a structured `HarnessError` before writing
+  files outside the runtime extraction root.
+
+## Why
+
+- A post-merge critical review of PR #94 confirmed the runtime extractor guard
+  exists, but flagged the missing regression coverage as a security-sensitive
+  follow-up.
+
+## Validation run(s)
+
+- `python -m pytest tests/test_sim_harness.py -q`
+  - result: pass (`27 passed`)
+
+## Follow-up items
+
+- None.
+
+## Current State Sync
+
+- `CURRENT_STATE.md` updated: no; this was targeted test coverage for existing
+  behavior.

--- a/tests/test_sim_harness.py
+++ b/tests/test_sim_harness.py
@@ -219,11 +219,9 @@ def test_ensure_runtime_wraps_bad_zipfile_and_cleans_invalid_archive(monkeypatch
     assert not package.runtime_dir.exists()
 
 
-@pytest.mark.parametrize("member_name", ["../escape.txt", "/absolute-escape.txt"])
-def test_safe_extract_zip_rejects_unsafe_member_paths(member_name: str, tmp_path: Path):
+def assert_unsafe_zip_member_rejected(member_name: str, escaped_path: Path, tmp_path: Path):
     archive_path = tmp_path / "unsafe.zip"
     destination = tmp_path / "runtime"
-    escaped = tmp_path / "escape.txt"
     with zipfile.ZipFile(archive_path, "w") as payload:
         payload.writestr(member_name, "outside")
 
@@ -232,8 +230,17 @@ def test_safe_extract_zip_rejects_unsafe_member_paths(member_name: str, tmp_path
 
     assert exc.value.status == "missing_runtime"
     assert "Unsafe path" in exc.value.message
-    assert not escaped.exists()
+    assert not escaped_path.exists()
     assert not any(destination.rglob("*"))
+
+
+def test_safe_extract_zip_rejects_parent_traversal_member(tmp_path: Path):
+    assert_unsafe_zip_member_rejected("../escape.txt", tmp_path / "escape.txt", tmp_path)
+
+
+def test_safe_extract_zip_rejects_absolute_member_path(tmp_path: Path):
+    escaped_path = tmp_path / "absolute-escape.txt"
+    assert_unsafe_zip_member_rejected(str(escaped_path), escaped_path, tmp_path)
 
 
 def test_stage_project_reuses_build_install_spec_and_excludes_tests(tmp_path: Path):

--- a/tests/test_sim_harness.py
+++ b/tests/test_sim_harness.py
@@ -219,6 +219,23 @@ def test_ensure_runtime_wraps_bad_zipfile_and_cleans_invalid_archive(monkeypatch
     assert not package.runtime_dir.exists()
 
 
+@pytest.mark.parametrize("member_name", ["../escape.txt", "/absolute-escape.txt"])
+def test_safe_extract_zip_rejects_unsafe_member_paths(member_name: str, tmp_path: Path):
+    archive_path = tmp_path / "unsafe.zip"
+    destination = tmp_path / "runtime"
+    escaped = tmp_path / "escape.txt"
+    with zipfile.ZipFile(archive_path, "w") as payload:
+        payload.writestr(member_name, "outside")
+
+    with pytest.raises(harness.HarnessError) as exc:
+        harness.safe_extract_zip(archive_path, destination)
+
+    assert exc.value.status == "missing_runtime"
+    assert "Unsafe path" in exc.value.message
+    assert not escaped.exists()
+    assert not any(destination.rglob("*"))
+
+
 def test_stage_project_reuses_build_install_spec_and_excludes_tests(tmp_path: Path):
     persist = harness.stage_project("SensorList", tmp_path / "persist")
     assert (persist / "scripts" / "SensorList" / "main.lua").exists()


### PR DESCRIPTION
## Summary

Follow-up to PR #94's post-merge critical review.

- Adds direct regression coverage for unsafe WebSimulator ZIP member paths in `safe_extract_zip()`.
- Covers both parent-directory traversal and native absolute-path archive members.
- Verifies the structured `HarnessError` is raised and no escaped target or extraction output is left behind.
- Records the follow-up in repo memory and refreshes the generated memory catalog.

## Subagent Review

Reviewed the narrow follow-up diff at `3ced860`.

No bugs or actionable suggestions found. The new traversal tests call `harness.safe_extract_zip()` directly, cover parent-directory and native absolute-path archive members, assert the structured `HarnessError`, and verify neither the escape target nor extracted destination contents are left behind. The absolute-path case is constructed from `tmp_path`, so it remains native and portable across Windows, Linux, and macOS. `git diff --check` was clean and `tests/test_sim_harness.py` passes with `27 passed`.

## Validation

- `python -m pytest tests/test_sim_harness.py -q` -> 27 passed
- `python -m pytest tests/test_memory_catalog_sync.py -q` -> 27 passed
- `python -m pytest tests/test_sim_harness.py tests/test_build_py.py tests/test_docs_commands.py tests/test_docs_contracts.py tests/test_memory_catalog_sync.py tests/test_prompt_guardrails.py -q` -> 310 passed, 25 skipped

## Notes

- Follow-up to #94 / #93; PR #94 is already merged via merge commit `b33de23`.
- Intended merge strategy: merge commit, to preserve the review-iteration commits requested for this closeout.